### PR TITLE
Add offscreen Rive renderer and Python bindings

### DIFF
--- a/modules/yup_gui/artboard/yup_RiveOffscreenRenderer.cpp
+++ b/modules/yup_gui/artboard/yup_RiveOffscreenRenderer.cpp
@@ -1,0 +1,628 @@
+/*
+  ==============================================================================
+
+   This file is part of the YUP library.
+   Copyright (c) 2025 - kunitoki@gmail.com
+
+   YUP is an open source library subject to open-source licensing.
+
+   The code included in this file is provided under the terms of the ISC license
+   http://www.isc.org/downloads/software-support-policy/isc-license. Permission
+   to use, copy, modify, and/or distribute this software for any purpose with or
+   without fee is hereby granted provided that the above copyright notice and
+   this permission notice appear in all copies.
+
+   YUP IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
+   EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
+   DISCLAIMED.
+
+  ==============================================================================
+*/
+
+#include "yup_gui.h"
+
+#include "artboard/yup_RiveOffscreenRenderer.h"
+
+#include "artboard/yup_ArtboardFile.h"
+
+#include <array>
+#include <cstring>
+#include <optional>
+
+#if YUP_WINDOWS && YUP_RIVE_USE_D3D
+
+#include <d3d11.h>
+#include <dxgi1_2.h>
+#include <wrl/client.h>
+
+#include "rive/layout.hpp"
+#include "rive/animation/linear_animation_instance.hpp"
+#include "rive/animation/state_machine_instance.hpp"
+#include "rive/renderer/d3d/d3d.hpp"
+#include "rive/renderer/d3d11/render_context_d3d_impl.hpp"
+#include "rive/renderer/rive_renderer.hpp"
+
+namespace yup
+{
+
+namespace
+{
+constexpr DXGI_FORMAT kRenderFormat = DXGI_FORMAT_B8G8R8A8_UNORM;
+
+[[nodiscard]] std::string makeErrorMessage (HRESULT hr)
+{
+    std::array<wchar_t, 256> buffer {};
+    ::FormatMessageW (FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+                      nullptr,
+                      static_cast<DWORD> (hr),
+                      0,
+                      buffer.data(),
+                      static_cast<DWORD> (buffer.size()),
+                      nullptr);
+
+    return String (buffer.data()).trim().toStdString();
+}
+
+[[nodiscard]] D3D11_TEXTURE2D_DESC makeTextureDescription (UINT width, UINT height, D3D11_USAGE usage, UINT bindFlags, UINT cpuFlags)
+{
+    D3D11_TEXTURE2D_DESC desc {};
+    desc.Width = width;
+    desc.Height = height;
+    desc.MipLevels = 1;
+    desc.ArraySize = 1;
+    desc.Format = kRenderFormat;
+    desc.SampleDesc.Count = 1;
+    desc.SampleDesc.Quality = 0;
+    desc.Usage = usage;
+    desc.BindFlags = bindFlags;
+    desc.CPUAccessFlags = cpuFlags;
+    desc.MiscFlags = 0;
+    return desc;
+}
+
+[[nodiscard]] rive::gpu::RenderContext::FrameDescriptor makeFrameDescriptor (int width, int height)
+{
+    rive::gpu::RenderContext::FrameDescriptor descriptor {};
+    descriptor.renderTargetWidth = static_cast<uint32_t> (width);
+    descriptor.renderTargetHeight = static_cast<uint32_t> (height);
+    descriptor.loadAction = rive::gpu::LoadAction::clear;
+    descriptor.clearColor = 0x00000000;
+    return descriptor;
+}
+
+} // namespace
+
+struct RiveOffscreenRenderer::Impl
+{
+    explicit Impl (int widthIn, int heightIn)
+        : width (widthIn),
+          height (heightIn),
+          rowStride (static_cast<std::size_t> (widthIn) * 4),
+          frameBuffer (std::make_shared<std::vector<uint8>> (static_cast<std::size_t> (widthIn) * static_cast<std::size_t> (heightIn) * 4u))
+    {
+        initialise();
+    }
+
+    ~Impl() = default;
+
+    bool isValid() const noexcept { return initialised; }
+
+    Result load (const File& fileToLoad, const String& artboardName)
+    {
+        if (! initialised)
+            return Result::fail ("Rive offscreen renderer is not available");
+
+        auto factory = renderContext->factory();
+        if (factory == nullptr)
+            return Result::fail ("Missing Rive factory");
+
+        auto loadResult = ArtboardFile::load (fileToLoad, *factory);
+        if (! loadResult)
+        {
+            lastError = loadResult.getErrorMessage();
+            return Result::fail (lastError);
+        }
+
+        artboardFile = loadResult.getValue();
+
+        auto* riveFile = artboardFile->getRiveFile();
+        if (riveFile == nullptr)
+            return Result::fail ("Loaded Rive file is invalid");
+
+        std::unique_ptr<rive::ArtboardInstance> loadedArtboard;
+
+        if (artboardName.isNotEmpty())
+            loadedArtboard = riveFile->artboardNamed (artboardName.toStdString());
+        else
+            loadedArtboard = riveFile->artboardDefault();
+
+        if (loadedArtboard == nullptr)
+            return Result::fail ("Unable to create artboard instance");
+
+        artboard = std::move (loadedArtboard);
+        updateViewTransform();
+
+        resetScenes();
+
+        if (! scene)
+            return Result::fail ("Artboard does not contain a playable scene");
+
+        scene->advanceAndApply (0.0f);
+        renderFrame();
+        return Result::ok();
+    }
+
+    StringArray listAnimations() const
+    {
+        StringArray names;
+
+        if (artboard == nullptr)
+            return names;
+
+        const auto animationCount = artboard->animationCount();
+        for (std::size_t index = 0; index < animationCount; ++index)
+        {
+            if (auto* animation = artboard->animation (index))
+                names.add (String (animation->name()));
+        }
+
+        return names;
+    }
+
+    StringArray listStateMachines() const
+    {
+        StringArray names;
+
+        if (artboard == nullptr)
+            return names;
+
+        const auto machineCount = artboard->stateMachineCount();
+        for (std::size_t index = 0; index < machineCount; ++index)
+        {
+            if (auto* machine = artboard->stateMachine (index))
+                names.add (String (machine->name()));
+        }
+
+        return names;
+    }
+
+    bool playAnimation (const String& name, bool loop)
+    {
+        if (artboard == nullptr)
+            return false;
+
+        animation.reset();
+        stateMachine.reset();
+        sceneHolder.reset();
+
+        animation = artboard->animationNamed (name.toStdString());
+        if (animation == nullptr)
+            return false;
+
+        animation->loopValue (loop ? static_cast<int> (rive::Loop::loop) : static_cast<int> (rive::Loop::oneShot));
+        scene = animation.get();
+        scene->advanceAndApply (0.0f);
+        return true;
+    }
+
+    bool playStateMachine (const String& name)
+    {
+        if (artboard == nullptr)
+            return false;
+
+        animation.reset();
+        stateMachine.reset();
+        sceneHolder.reset();
+
+        stateMachine = artboard->stateMachineNamed (name.toStdString());
+        if (stateMachine == nullptr)
+            return false;
+
+        scene = stateMachine.get();
+        scene->advanceAndApply (0.0f);
+        return true;
+    }
+
+    void stop()
+    {
+        animation.reset();
+        stateMachine.reset();
+        sceneHolder.reset();
+        scene = nullptr;
+    }
+
+    bool setBoolInput (const String& name, bool value)
+    {
+        if (stateMachine == nullptr)
+            return false;
+
+        if (auto* input = stateMachine->getBool (name.toStdString()))
+        {
+            input->value (value);
+            return true;
+        }
+
+        return false;
+    }
+
+    bool setNumberInput (const String& name, double value)
+    {
+        if (stateMachine == nullptr)
+            return false;
+
+        if (auto* input = stateMachine->getNumber (name.toStdString()))
+        {
+            input->value (static_cast<float> (value));
+            return true;
+        }
+
+        return false;
+    }
+
+    bool fireTrigger (const String& name)
+    {
+        if (stateMachine == nullptr)
+            return false;
+
+        if (auto* trigger = stateMachine->getTrigger (name.toStdString()))
+        {
+            trigger->fire();
+            return true;
+        }
+
+        return false;
+    }
+
+    bool advance (float deltaSeconds)
+    {
+        if (! initialised || paused || scene == nullptr)
+            return false;
+
+        const auto keepAnimating = scene->advanceAndApply (deltaSeconds);
+        renderFrame();
+        return keepAnimating;
+    }
+
+    void setPaused (bool shouldPause) { paused = shouldPause; }
+    bool isPaused() const noexcept { return paused; }
+
+    int getWidth() const noexcept { return width; }
+    int getHeight() const noexcept { return height; }
+    std::size_t getStride() const noexcept { return rowStride; }
+
+    const std::vector<uint8>& getFrameBuffer() const noexcept { return *frameBuffer; }
+    std::shared_ptr<const std::vector<uint8>> getFrameBufferShared() const noexcept { return frameBuffer; }
+
+    const String& getLastError() const noexcept { return lastError; }
+
+private:
+    void initialise()
+    {
+        using Microsoft::WRL::ComPtr;
+
+        UINT creationFlags = D3D11_CREATE_DEVICE_BGRA_SUPPORT;
+#if YUP_DEBUG
+        creationFlags |= D3D11_CREATE_DEVICE_DEBUG;
+#endif
+
+        const D3D_FEATURE_LEVEL requestedLevels[] = { D3D_FEATURE_LEVEL_11_1, D3D_FEATURE_LEVEL_11_0 };
+
+        ComPtr<ID3D11Device> createdDevice;
+        ComPtr<ID3D11DeviceContext> createdContext;
+
+        auto hr = D3D11CreateDevice (nullptr,
+                                      D3D_DRIVER_TYPE_HARDWARE,
+                                      nullptr,
+                                      creationFlags,
+                                      requestedLevels,
+                                      static_cast<UINT> (std::size (requestedLevels)),
+                                      D3D11_SDK_VERSION,
+                                      createdDevice.GetAddressOf(),
+                                      nullptr,
+                                      createdContext.GetAddressOf());
+
+        if (FAILED (hr))
+        {
+            lastError = String (makeErrorMessage (hr));
+            return;
+        }
+
+        device = std::move (createdDevice);
+        deviceContext = std::move (createdContext);
+
+        rive::gpu::D3DContextOptions contextOptions;
+        renderContext = rive::gpu::RenderContextD3DImpl::MakeContext (device, deviceContext, contextOptions);
+
+        if (renderContext == nullptr)
+        {
+            lastError = "Unable to create Rive render context";
+            return;
+        }
+
+        auto* renderContextImpl = renderContext->static_impl_cast<rive::gpu::RenderContextD3DImpl>();
+        renderTarget = renderContextImpl->makeRenderTarget (static_cast<uint32_t> (width), static_cast<uint32_t> (height));
+
+        if (! renderTarget)
+        {
+            lastError = "Unable to create render target";
+            return;
+        }
+
+        auto desc = makeTextureDescription (static_cast<UINT> (width), static_cast<UINT> (height), D3D11_USAGE_DEFAULT, D3D11_BIND_RENDER_TARGET, 0);
+        hr = device->CreateTexture2D (&desc, nullptr, renderTexture.GetAddressOf());
+        if (FAILED (hr))
+        {
+            lastError = String (makeErrorMessage (hr));
+            return;
+        }
+
+        desc = makeTextureDescription (static_cast<UINT> (width), static_cast<UINT> (height), D3D11_USAGE_STAGING, 0, D3D11_CPU_ACCESS_READ);
+        hr = device->CreateTexture2D (&desc, nullptr, stagingTexture.GetAddressOf());
+        if (FAILED (hr))
+        {
+            lastError = String (makeErrorMessage (hr));
+            return;
+        }
+
+        renderer = std::make_unique<rive::RiveRenderer> (renderContext.get());
+        initialised = true;
+    }
+
+    void resetScenes()
+    {
+        scene = nullptr;
+        animation.reset();
+        stateMachine.reset();
+        sceneHolder.reset();
+
+        if (artboard != nullptr)
+            sceneHolder = artboard->defaultScene();
+
+        scene = sceneHolder.get();
+    }
+
+    void updateViewTransform()
+    {
+        if (artboard == nullptr)
+        {
+            viewTransform = rive::Mat2D::identity();
+            return;
+        }
+
+        rive::AABB targetBounds { 0.0f, 0.0f, static_cast<float> (width), static_cast<float> (height) };
+        const auto artboardBounds = artboard->bounds();
+        viewTransform = rive::computeAlignment (rive::Fit::contain, rive::Alignment::center, targetBounds, artboardBounds);
+    }
+
+    void renderFrame()
+    {
+        if (! initialised || scene == nullptr)
+            return;
+
+        rive::gpu::RenderContext::FrameDescriptor frameDescriptor = makeFrameDescriptor (width, height);
+        renderContext->beginFrame (frameDescriptor);
+
+        renderTarget->setTargetTexture (renderTexture.Get());
+
+        renderer->save();
+        renderer->transform (viewTransform);
+        scene->draw (renderer.get());
+        renderer->restore();
+
+        rive::gpu::RenderContext::FlushResources flushDescriptor {};
+        flushDescriptor.renderTarget = renderTarget.get();
+        renderContext->flush (flushDescriptor);
+
+        renderTarget->setTargetTexture (nullptr);
+
+        deviceContext->CopyResource (stagingTexture.Get(), renderTexture.Get());
+
+        D3D11_MAPPED_SUBRESOURCE mapped {};
+        auto hr = deviceContext->Map (stagingTexture.Get(), 0, D3D11_MAP_READ, 0, &mapped);
+        if (FAILED (hr))
+        {
+            lastError = String (makeErrorMessage (hr));
+            return;
+        }
+
+        auto* srcBytes = static_cast<const uint8*> (mapped.pData);
+        auto* dstBytes = frameBuffer->data();
+
+        for (int row = 0; row < height; ++row)
+        {
+            const auto srcRow = srcBytes + static_cast<std::size_t> (row) * mapped.RowPitch;
+            auto* dstRow = dstBytes + static_cast<std::size_t> (row) * rowStride;
+            std::memcpy (dstRow, srcRow, rowStride);
+        }
+
+        deviceContext->Unmap (stagingTexture.Get(), 0);
+    }
+
+    Microsoft::WRL::ComPtr<ID3D11Device> device;
+    Microsoft::WRL::ComPtr<ID3D11DeviceContext> deviceContext;
+    Microsoft::WRL::ComPtr<ID3D11Texture2D> renderTexture;
+    Microsoft::WRL::ComPtr<ID3D11Texture2D> stagingTexture;
+
+    std::unique_ptr<rive::gpu::RenderContext> renderContext;
+    rive::rcp<rive::gpu::RenderTargetD3D> renderTarget;
+    std::unique_ptr<rive::RiveRenderer> renderer;
+
+    std::shared_ptr<std::vector<uint8>> frameBuffer;
+
+    std::shared_ptr<ArtboardFile> artboardFile;
+    std::unique_ptr<rive::ArtboardInstance> artboard;
+    std::unique_ptr<rive::Scene> sceneHolder;
+    std::unique_ptr<rive::LinearAnimationInstance> animation;
+    std::unique_ptr<rive::StateMachineInstance> stateMachine;
+    rive::Scene* scene = nullptr;
+
+    rive::Mat2D viewTransform = rive::Mat2D::identity();
+
+    String lastError;
+
+    int width = 0;
+    int height = 0;
+    std::size_t rowStride = 0;
+
+    bool initialised = false;
+    bool paused = false;
+};
+
+} // namespace yup
+
+#else
+
+namespace yup
+{
+
+struct RiveOffscreenRenderer::Impl
+{
+    Impl (int widthIn, int heightIn)
+        : width (widthIn), height (heightIn)
+    {
+        frameBuffer = std::make_shared<std::vector<uint8>> (static_cast<std::size_t> (width) * static_cast<std::size_t> (height) * 4u, 0);
+    }
+
+    bool isValid() const noexcept { return false; }
+
+    Result load (const File&, const String&)
+    {
+        lastError = "Direct3D11 offscreen rendering is only available on Windows";
+        return Result::fail (lastError);
+    }
+
+    StringArray listAnimations() const { return {}; }
+    StringArray listStateMachines() const { return {}; }
+    bool playAnimation (const String&, bool) { return false; }
+    bool playStateMachine (const String&) { return false; }
+    void stop() {}
+    bool setBoolInput (const String&, bool) { return false; }
+    bool setNumberInput (const String&, double) { return false; }
+    bool fireTrigger (const String&) { return false; }
+    bool advance (float) { return false; }
+    void setPaused (bool) {}
+    bool isPaused() const noexcept { return false; }
+    int getWidth() const noexcept { return width; }
+    int getHeight() const noexcept { return height; }
+    std::size_t getStride() const noexcept { return static_cast<std::size_t> (width) * 4u; }
+    const std::vector<uint8>& getFrameBuffer() const noexcept { return *frameBuffer; }
+    std::shared_ptr<const std::vector<uint8>> getFrameBufferShared() const noexcept { return frameBuffer; }
+    const String& getLastError() const noexcept { return lastError; }
+
+    int width = 0;
+    int height = 0;
+    std::shared_ptr<std::vector<uint8>> frameBuffer;
+    String lastError;
+};
+
+} // namespace yup
+
+#endif
+
+namespace yup
+{
+
+RiveOffscreenRenderer::RiveOffscreenRenderer (int width, int height)
+    : impl (std::make_unique<Impl> (width, height))
+{
+}
+
+RiveOffscreenRenderer::~RiveOffscreenRenderer() = default;
+
+bool RiveOffscreenRenderer::isValid() const noexcept
+{
+    return impl->isValid();
+}
+
+Result RiveOffscreenRenderer::load (const File& file, const String& artboardName)
+{
+    return impl->load (file, artboardName);
+}
+
+StringArray RiveOffscreenRenderer::listAnimations() const
+{
+    return impl->listAnimations();
+}
+
+StringArray RiveOffscreenRenderer::listStateMachines() const
+{
+    return impl->listStateMachines();
+}
+
+bool RiveOffscreenRenderer::playAnimation (const String& animationName, bool shouldLoop)
+{
+    return impl->playAnimation (animationName, shouldLoop);
+}
+
+bool RiveOffscreenRenderer::playStateMachine (const String& machineName)
+{
+    return impl->playStateMachine (machineName);
+}
+
+void RiveOffscreenRenderer::stop()
+{
+    impl->stop();
+}
+
+void RiveOffscreenRenderer::setPaused (bool shouldPause)
+{
+    impl->setPaused (shouldPause);
+}
+
+bool RiveOffscreenRenderer::isPaused() const noexcept
+{
+    return impl->isPaused();
+}
+
+bool RiveOffscreenRenderer::setBoolInput (const String& name, bool value)
+{
+    return impl->setBoolInput (name, value);
+}
+
+bool RiveOffscreenRenderer::setNumberInput (const String& name, double value)
+{
+    return impl->setNumberInput (name, value);
+}
+
+bool RiveOffscreenRenderer::fireTriggerInput (const String& name)
+{
+    return impl->fireTrigger (name);
+}
+
+bool RiveOffscreenRenderer::advance (float deltaSeconds)
+{
+    return impl->advance (deltaSeconds);
+}
+
+int RiveOffscreenRenderer::getWidth() const noexcept
+{
+    return impl->getWidth();
+}
+
+int RiveOffscreenRenderer::getHeight() const noexcept
+{
+    return impl->getHeight();
+}
+
+std::size_t RiveOffscreenRenderer::getRowStride() const noexcept
+{
+    return impl->getStride();
+}
+
+const std::vector<uint8>& RiveOffscreenRenderer::getFrameBuffer() const noexcept
+{
+    return impl->getFrameBuffer();
+}
+
+std::shared_ptr<const std::vector<uint8>> RiveOffscreenRenderer::getFrameBufferShared() const noexcept
+{
+    return impl->getFrameBufferShared();
+}
+
+const String& RiveOffscreenRenderer::getLastError() const noexcept
+{
+    return impl->getLastError();
+}
+
+} // namespace yup
+

--- a/modules/yup_gui/artboard/yup_RiveOffscreenRenderer.h
+++ b/modules/yup_gui/artboard/yup_RiveOffscreenRenderer.h
@@ -1,0 +1,113 @@
+/*
+  ==============================================================================
+
+   This file is part of the YUP library.
+   Copyright (c) 2025 - kunitoki@gmail.com
+
+   YUP is an open source library subject to open-source licensing.
+
+   The code included in this file is provided under the terms of the ISC license
+   http://www.isc.org/downloads/software-support-policy/isc-license. Permission
+   to use, copy, modify, and/or distribute this software for any purpose with or
+   without fee is hereby granted provided that the above copyright notice and
+   this permission notice appear in all copies.
+
+   YUP IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
+   EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
+   DISCLAIMED.
+
+  ==============================================================================
+*/
+
+#pragma once
+
+namespace yup
+{
+
+class ArtboardFile;
+
+//==============================================================================
+/**
+    Offscreen renderer for Rive artboards using the Direct3D11 backend.
+
+    The renderer manages an offscreen GPU context, loads .riv files into
+    artboards, advances animations or state machines, and exposes the rendered
+    BGRA frame to callers.
+
+    On platforms where the Direct3D backend is not available the renderer will
+    fail gracefully and report an informative error when attempting to load
+    content or render frames.
+*/
+class YUP_API RiveOffscreenRenderer
+{
+public:
+    /** Creates a renderer for the given output dimensions. */
+    RiveOffscreenRenderer (int width, int height);
+
+    /** Destructor. */
+    ~RiveOffscreenRenderer();
+
+    /** Returns true when the underlying GPU resources were initialised. */
+    bool isValid() const noexcept;
+
+    /** Loads a Rive file from disk. */
+    Result load (const File& file, const String& artboardName = {});
+
+    /** Lists the available linear animations in the currently loaded artboard. */
+    StringArray listAnimations() const;
+
+    /** Lists the available state machines in the currently loaded artboard. */
+    StringArray listStateMachines() const;
+
+    /** Starts playing the specified linear animation. */
+    bool playAnimation (const String& animationName, bool shouldLoop = true);
+
+    /** Starts playing the specified state machine. */
+    bool playStateMachine (const String& machineName);
+
+    /** Stops any running animation or state machine. */
+    void stop();
+
+    /** Pauses or resumes advancement of the current scene. */
+    void setPaused (bool shouldPause);
+
+    /** Returns true when the renderer is paused. */
+    bool isPaused() const noexcept;
+
+    /** Sets a boolean input on the active state machine. */
+    bool setBoolInput (const String& name, bool value);
+
+    /** Sets a numeric input on the active state machine. */
+    bool setNumberInput (const String& name, double value);
+
+    /** Fires a trigger input on the active state machine. */
+    bool fireTriggerInput (const String& name);
+
+    /** Advances the active scene and renders a new frame. */
+    bool advance (float deltaSeconds);
+
+    /** Returns the width of the offscreen surface. */
+    int getWidth() const noexcept;
+
+    /** Returns the height of the offscreen surface. */
+    int getHeight() const noexcept;
+
+    /** Returns the stride in bytes for each row in the frame buffer. */
+    std::size_t getRowStride() const noexcept;
+
+    /** Returns the most recent BGRA frame contents. */
+    const std::vector<uint8>& getFrameBuffer() const noexcept;
+
+    /** Returns a shared reference to the frame buffer for use with Python bindings. */
+    std::shared_ptr<const std::vector<uint8>> getFrameBufferShared() const noexcept;
+
+    /** Returns the last error that occurred while operating the renderer. */
+    const String& getLastError() const noexcept;
+
+private:
+    struct Impl;
+    std::unique_ptr<Impl> impl;
+};
+
+} // namespace yup
+

--- a/modules/yup_gui/yup_gui.cpp
+++ b/modules/yup_gui/yup_gui.cpp
@@ -144,6 +144,7 @@
 #include "widgets/yup_ComboBox.cpp"
 #include "artboard/yup_ArtboardFile.cpp"
 #include "artboard/yup_Artboard.cpp"
+#include "artboard/yup_RiveOffscreenRenderer.cpp"
 #include "windowing/yup_DocumentWindow.cpp"
 #include "dialogs/yup_FileChooser.cpp"
 #include "themes/yup_ApplicationTheme.cpp"

--- a/modules/yup_gui/yup_gui.h
+++ b/modules/yup_gui/yup_gui.h
@@ -93,6 +93,7 @@
 #include "widgets/yup_ComboBox.h"
 #include "artboard/yup_ArtboardFile.h"
 #include "artboard/yup_Artboard.h"
+#include "artboard/yup_RiveOffscreenRenderer.h"
 #include "windowing/yup_DocumentWindow.h"
 #include "dialogs/yup_FileChooser.h"
 


### PR DESCRIPTION
## Summary
- add a Direct3D11-backed `RiveOffscreenRenderer` that can load artboards, advance scenes, and capture BGRA frames
- expose the offscreen renderer through the Python bindings with helpers for animation/state-machine control and numpy frame access

## Testing
- cmake -S . -B build -DYUP_ENABLE_TESTS=OFF *(fails: required package alsa missing)*

------
https://chatgpt.com/codex/tasks/task_e_68d29c675f448329a3fc87408c467a58