### PR TITLE
Add scaffolding for Rive offscreen engine and Python bindings

### DIFF
--- a/cmake/yup_modules.cmake
+++ b/cmake/yup_modules.cmake
@@ -642,6 +642,9 @@ macro (yup_add_default_modules modules_path)
     yup_add_module (${modules_path}/modules/yup_gui "${modules_definitions}" ${modules_group})
     add_library (yup::yup_gui ALIAS yup_gui)
 
+    yup_add_module (${modules_path}/modules/yup_rive_renderer "${modules_definitions}" ${modules_group})
+    add_library (yup::yup_rive_renderer ALIAS yup_rive_renderer)
+
     yup_add_module (${modules_path}/modules/yup_audio_basics "${modules_definitions}" ${modules_group})
     add_library (yup::yup_audio_basics ALIAS yup_audio_basics)
 

--- a/modules/yup_python/bindings/yup_YupRiveRenderer_bindings.cpp
+++ b/modules/yup_python/bindings/yup_YupRiveRenderer_bindings.cpp
@@ -1,0 +1,189 @@
+/*
+  ==============================================================================
+
+   This file is part of the YUP library.
+   Copyright (c) 2025 - kunitoki@gmail.com
+
+   YUP is an open source library subject to open-source licensing.
+
+   The code included in this file is provided under the terms of the ISC license
+   http://www.isc.org/downloads/software-support-policy/isc-license. Permission
+   to use, copy, modify, and/or distribute this software for any purpose with or
+   without fee is hereby granted provided that the above copyright notice and
+   this permission notice appear in all copies.
+
+   YUP IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
+   EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
+   DISCLAIMED.
+
+  ==============================================================================
+*/
+
+#include "yup_YupRiveRenderer_bindings.h"
+
+#if YUP_MODULE_AVAILABLE_yup_rive_renderer
+
+#include "../utilities/yup_PyBind11Includes.h"
+#include "../utilities/yup_PythonInterop.h"
+
+#include <yup_rive_renderer/yup_rive_renderer.h>
+
+#include <pybind11/numpy.h>
+#include <pybind11/stl.h>
+
+#include <optional>
+#include <cstring>
+#include <stdexcept>
+
+namespace yup::Bindings
+{
+namespace py = pybind11;
+using namespace py::literals;
+
+namespace
+{
+[[nodiscard]] static const char* inputTypeToString (StateMachineInputType type) noexcept
+{
+    switch (type)
+    {
+        case StateMachineInputType::boolean:
+            return "boolean";
+        case StateMachineInputType::number:
+            return "number";
+        case StateMachineInputType::trigger:
+        default:
+            return "trigger";
+    }
+}
+
+[[nodiscard]] static py::array frameToArray (const RiveAnimationEngine& engine)
+{
+    const auto view = engine.frameBuffer();
+
+    if (! view.isValid())
+        throw std::runtime_error ("No frame data available. Did you load a file?");
+
+    const auto width = static_cast<py::ssize_t> (view.width);
+    const auto height = static_cast<py::ssize_t> (view.height);
+    const auto channels = static_cast<py::ssize_t> (4);
+
+    auto array = py::array_t<std::uint8_t> ({ height, width, channels });
+    auto* dest = array.mutable_data();
+
+    const auto rowBytes = static_cast<std::size_t> (view.width) * 4u;
+    for (std::uint32_t y = 0; y < view.height; ++y)
+    {
+        const auto* src = view.data + (static_cast<std::size_t> (y) * view.rowStrideBytes);
+        std::memcpy (dest + static_cast<std::size_t> (y) * rowBytes, src, rowBytes);
+    }
+
+    return array;
+}
+
+[[nodiscard]] static py::tuple makeLoadResultTuple (const LoadResult& result)
+{
+    return py::make_tuple (result.success, result.message.toStdString());
+}
+
+[[nodiscard]] static std::vector<py::object> convertStringList (const std::vector<yup::String>& values)
+{
+    std::vector<py::object> output;
+    output.reserve (values.size());
+
+    for (const auto& value : values)
+        output.emplace_back (py::str (value.toStdString()));
+
+    return output;
+}
+
+} // namespace
+
+void registerYupRiveRendererBindings (py::module_& module)
+{
+    auto riveModule = module.def_submodule ("rive");
+
+    py::class_<RiveAnimationEngine> (riveModule, "AnimationEngine")
+        .def (py::init<>())
+        .def ("load_file",
+              [] (RiveAnimationEngine& engine,
+                  const std::string& path,
+                  std::optional<std::string> artboard,
+                  std::optional<std::uint32_t> width,
+                  std::optional<std::uint32_t> height)
+              {
+                  yup::File file { yup::String (path) };
+
+                  LoadOptions options;
+                  if (artboard.has_value())
+                      options.artboardName = yup::String (*artboard);
+                  if (width.has_value())
+                      options.widthOverride = width.value();
+                  if (height.has_value())
+                      options.heightOverride = height.value();
+
+                  return makeLoadResultTuple (engine.loadFromFile (file, options));
+              },
+              "path"_a,
+              "artboard"_a = std::nullopt,
+              "width"_a = std::nullopt,
+              "height"_a = std::nullopt)
+        .def ("unload", &RiveAnimationEngine::unload)
+        .def ("is_loaded", &RiveAnimationEngine::isLoaded)
+        .def ("artboard_names",
+              [] (const RiveAnimationEngine& engine)
+              {
+                  return convertStringList (engine.artboardNames());
+              })
+        .def ("animation_names",
+              [] (const RiveAnimationEngine& engine)
+              {
+                  return convertStringList (engine.animationNames());
+              })
+        .def ("state_machine_names",
+              [] (const RiveAnimationEngine& engine)
+              {
+                  return convertStringList (engine.stateMachineNames());
+              })
+        .def ("play_animation", &RiveAnimationEngine::playAnimation, "name"_a, "loop"_a = true)
+        .def ("play_state_machine", &RiveAnimationEngine::playStateMachine, "name"_a)
+        .def ("stop", &RiveAnimationEngine::stop)
+        .def ("pause", &RiveAnimationEngine::pause)
+        .def ("resume", &RiveAnimationEngine::resume)
+        .def ("is_paused", &RiveAnimationEngine::isPaused)
+        .def ("set_state_boolean", &RiveAnimationEngine::setStateMachineBoolean, "name"_a, "value"_a)
+        .def ("set_state_number", &RiveAnimationEngine::setStateMachineNumber, "name"_a, "value"_a)
+        .def ("fire_state_trigger", &RiveAnimationEngine::fireStateMachineTrigger, "name"_a)
+        .def ("state_machine_inputs",
+              [] (const RiveAnimationEngine& engine)
+              {
+                  py::list result;
+                  for (const auto& input : engine.stateMachineInputs())
+                  {
+                      py::dict item;
+                      item["name"] = py::str (input.name.toStdString());
+                      item["type"] = py::str (inputTypeToString (input.type));
+                      result.append (std::move (item));
+                  }
+                  return result;
+              })
+        .def ("advance",
+              [] (RiveAnimationEngine& engine, float deltaSeconds)
+              {
+                  py::gil_scoped_release release;
+                  return engine.advance (deltaSeconds);
+              },
+              "delta_seconds"_a)
+        .def ("frame_width", &RiveAnimationEngine::frameWidth)
+        .def ("frame_height", &RiveAnimationEngine::frameHeight)
+        .def ("frame_stride", &RiveAnimationEngine::frameRowStride)
+        .def ("frame_counter", &RiveAnimationEngine::frameCounter)
+        .def ("frame_data",
+              [] (const RiveAnimationEngine& engine)
+              {
+                  return frameToArray (engine);
+              });
+}
+
+} // namespace yup::Bindings
+
+#endif // YUP_MODULE_AVAILABLE_yup_rive_renderer

--- a/modules/yup_python/bindings/yup_YupRiveRenderer_bindings.h
+++ b/modules/yup_python/bindings/yup_YupRiveRenderer_bindings.h
@@ -1,0 +1,35 @@
+/*
+  ==============================================================================
+
+   This file is part of the YUP library.
+   Copyright (c) 2025 - kunitoki@gmail.com
+
+   YUP is an open source library subject to open-source licensing.
+
+   The code included in this file is provided under the terms of the ISC license
+   http://www.isc.org/downloads/software-support-policy/isc-license. Permission
+   to use, copy, modify, and/or distribute this software for any purpose with or
+   without fee is hereby granted provided that the above copyright notice and
+   this permission notice appear in all copies.
+
+   YUP IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
+   EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
+   DISCLAIMED.
+
+  ==============================================================================
+*/
+
+#pragma once
+
+namespace pybind11
+{
+class module_;
+}
+
+namespace yup::Bindings
+{
+
+void registerYupRiveRendererBindings (pybind11::module_& module);
+
+} // namespace yup::Bindings
+

--- a/modules/yup_python/modules/yup_YupMain_module.cpp
+++ b/modules/yup_python/modules/yup_YupMain_module.cpp
@@ -42,6 +42,10 @@
 #include "../bindings/yup_YupGui_bindings.h"
 #endif
 
+#if YUP_MODULE_AVAILABLE_yup_rive_renderer
+#include "../bindings/yup_YupRiveRenderer_bindings.h"
+#endif
+
 /*
 #if YUP_MODULE_AVAILABLE_yup_audio_basics
 #include "../bindings/yup_YupAudioBasics_bindings.h"
@@ -94,6 +98,10 @@ PYBIND11_MODULE (YUP_PYTHON_MODULE_NAME, m)
 
 #if YUP_MODULE_AVAILABLE_yup_gui
     yup::Bindings::registerYupGuiBindings (m);
+#endif
+
+#if YUP_MODULE_AVAILABLE_yup_rive_renderer
+    yup::Bindings::registerYupRiveRendererBindings (m);
 #endif
 
     /*

--- a/modules/yup_python/yup_python_rive_renderer.cpp
+++ b/modules/yup_python/yup_python_rive_renderer.cpp
@@ -1,0 +1,24 @@
+/*
+  ==============================================================================
+
+   This file is part of the YUP library.
+   Copyright (c) 2025 - kunitoki@gmail.com
+
+   YUP is an open source library subject to open-source licensing.
+
+   The code included in this file is provided under the terms of the ISC license
+   http://www.isc.org/downloads/software-support-policy/isc-license. Permission
+   to use, copy, modify, and/or distribute this software for any purpose with or
+   without fee is hereby granted provided that the above copyright notice and
+   this permission notice appear in all copies.
+
+   YUP IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
+   EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
+   DISCLAIMED.
+
+  ==============================================================================
+*/
+
+#if YUP_MODULE_AVAILABLE_yup_rive_renderer
+#include "bindings/yup_YupRiveRenderer_bindings.cpp"
+#endif

--- a/modules/yup_rive_renderer/yup_rive_renderer.cpp
+++ b/modules/yup_rive_renderer/yup_rive_renderer.cpp
@@ -1,0 +1,504 @@
+/*
+  ==============================================================================
+
+   This file is part of the YUP library.
+   Copyright (c) 2025 - kunitoki@gmail.com
+
+   YUP is an open source library subject to open-source licensing.
+
+   The code included in this file is provided under the terms of the ISC license
+   http://www.isc.org/downloads/software-support-policy/isc-license. Permission
+   to use, copy, modify, and/or distribute this software for any purpose with or
+   without fee is hereby granted provided that the above copyright notice and
+   this permission notice appear in all copies.
+
+   YUP IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
+   EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
+   DISCLAIMED.
+
+  ==============================================================================
+*/
+
+#include "yup_rive_renderer.h"
+
+#include <yup_core/files/yup_FileInputStream.h>
+#include <yup_core/misc/yup_Result.h>
+
+#include <rive/animation/loop.hpp>
+#include <rive/animation/state_machine_input_instance.hpp>
+#include <rive/importers/import_result.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+
+namespace yup::rive_offscreen
+{
+namespace
+{
+[[nodiscard]] static yup::String importErrorToString (rive::ImportResult result)
+{
+    switch (result)
+    {
+        case rive::ImportResult::success:
+            return {};
+        case rive::ImportResult::unsupportedVersion:
+            return "Unsupported Rive file version";
+        case rive::ImportResult::malformed:
+        default:
+            return "Malformed Rive file";
+    }
+}
+
+[[nodiscard]] static std::vector<yup::String> collectArtboardNames (const rive::File& file)
+{
+    std::vector<yup::String> names;
+    names.reserve (file.artboardCount());
+
+    for (size_t i = 0; i < file.artboardCount(); ++i)
+        names.emplace_back (file.artboardNameAt (i));
+
+    return names;
+}
+
+[[nodiscard]] static std::vector<yup::String> collectAnimationNames (const rive::ArtboardInstance& artboard)
+{
+    std::vector<yup::String> names;
+    names.reserve (artboard.animationCount());
+
+    for (size_t i = 0; i < artboard.animationCount(); ++i)
+        if (auto* animation = artboard.animation (i))
+            names.emplace_back (animation->name());
+
+    return names;
+}
+
+[[nodiscard]] static std::vector<yup::String> collectStateMachineNames (const rive::ArtboardInstance& artboard)
+{
+    std::vector<yup::String> names;
+    names.reserve (artboard.stateMachineCount());
+
+    for (size_t i = 0; i < artboard.stateMachineCount(); ++i)
+        if (auto* stateMachine = artboard.stateMachine (i))
+            names.emplace_back (stateMachine->name());
+
+    return names;
+}
+
+[[nodiscard]] static std::vector<std::uint8_t> readEntireFile (const yup::File& file, yup::String& error)
+{
+    yup::FileInputStream stream { file };
+
+    if (! stream.openedOk())
+    {
+        error = stream.getStatus().getErrorMessage();
+        return {};
+    }
+
+    const auto totalLength = stream.getTotalLength();
+
+    if (totalLength <= 0)
+    {
+        error = "File is empty";
+        return {};
+    }
+
+    std::vector<std::uint8_t> bytes;
+    bytes.resize (static_cast<std::size_t> (totalLength));
+
+    std::size_t totalRead = 0;
+    while (totalRead < bytes.size())
+    {
+        const auto bytesRemaining = bytes.size() - totalRead;
+        const auto chunkSize = static_cast<int> (std::min<std::size_t> (bytesRemaining, std::numeric_limits<int>::max()));
+
+        const auto readNow = stream.read (bytes.data() + totalRead, chunkSize);
+        if (readNow <= 0)
+        {
+            error = "Failed to read artboard file";
+            bytes.clear();
+            return bytes;
+        }
+
+        totalRead += static_cast<std::size_t> (readNow);
+    }
+
+    return bytes;
+}
+
+[[nodiscard]] static std::uint32_t normaliseDimension (float value, std::uint32_t fallback)
+{
+    if (value <= 0.0f)
+        return fallback;
+
+    return static_cast<std::uint32_t> (std::max (1.0f, std::round (value)));
+}
+
+[[nodiscard]] static std::string toStorageKey (const yup::String& value)
+{
+    return value.toStdString();
+}
+
+} // namespace
+
+//==============================================================================
+
+RiveAnimationEngine::RiveAnimationEngine() = default;
+RiveAnimationEngine::~RiveAnimationEngine() = default;
+
+bool RiveAnimationEngine::isLoaded() const noexcept
+{
+    return riveFile != nullptr && artboard != nullptr;
+}
+
+LoadResult RiveAnimationEngine::loadFromFile (const yup::File& file, const LoadOptions& options)
+{
+    unload();
+
+    if (! file.existsAsFile())
+        return LoadResult::fail ("Rive file does not exist");
+
+    yup::String errorMessage;
+    auto bytes = readEntireFile (file, errorMessage);
+
+    if (bytes.empty())
+        return LoadResult::fail (std::move (errorMessage));
+
+    rive::ImportResult importResult = rive::ImportResult::malformed;
+    auto importedFile = rive::File::import (
+        { bytes.data(), bytes.size() },
+        std::addressof (factory),
+        std::addressof (importResult));
+
+    if (importedFile == nullptr)
+        return LoadResult::fail (importErrorToString (importResult));
+
+    std::unique_ptr<rive::ArtboardInstance> importedArtboard;
+
+    if (options.artboardName.isNotEmpty())
+        importedArtboard = importedFile->artboardNamed (options.artboardName.toStdString());
+    else
+        importedArtboard = importedFile->artboardDefault();
+
+    if (importedArtboard == nullptr)
+        return LoadResult::fail ("Unable to locate requested artboard");
+
+    const auto artboardWidth = options.widthOverride.value_or (normaliseDimension (importedArtboard->width(), 1920));
+    const auto artboardHeight = options.heightOverride.value_or (normaliseDimension (importedArtboard->height(), 1080));
+
+    width = std::max<std::uint32_t> (1, artboardWidth);
+    height = std::max<std::uint32_t> (1, artboardHeight);
+    rowStride = static_cast<std::size_t> (width) * 4u;
+
+    riveFile = std::move (importedFile);
+    artboard = std::move (importedArtboard);
+
+    artboard->advance (0.0f);
+
+    ensureFrameStorage();
+    clearPlayback();
+    cachedInputs.clear();
+
+    return LoadResult::ok();
+}
+
+void RiveAnimationEngine::unload()
+{
+    clearPlayback();
+    cachedInputs.clear();
+    boolInputs.clear();
+    numberInputs.clear();
+    triggerInputs.clear();
+
+    artboard.reset();
+    riveFile.reset();
+
+    frameData.clear();
+    width = 0;
+    height = 0;
+    rowStride = 0;
+    frameId = 0;
+}
+
+std::vector<yup::String> RiveAnimationEngine::artboardNames() const
+{
+    if (riveFile == nullptr)
+        return {};
+
+    return collectArtboardNames (*riveFile);
+}
+
+std::vector<yup::String> RiveAnimationEngine::animationNames() const
+{
+    if (artboard == nullptr)
+        return {};
+
+    return collectAnimationNames (*artboard);
+}
+
+std::vector<yup::String> RiveAnimationEngine::stateMachineNames() const
+{
+    if (artboard == nullptr)
+        return {};
+
+    return collectStateMachineNames (*artboard);
+}
+
+bool RiveAnimationEngine::playAnimation (const yup::String& name, bool loop)
+{
+    if (artboard == nullptr)
+        return false;
+
+    auto instance = artboard->animationNamed (name.toStdString());
+    if (instance == nullptr)
+        return false;
+
+    clearPlayback();
+
+    loopAnimation = loop;
+    activeAnimation = std::move (instance);
+    activeAnimation->loopValue (loop ? static_cast<int> (rive::Loop::loop) : static_cast<int> (rive::Loop::oneShot));
+
+    return true;
+}
+
+bool RiveAnimationEngine::playStateMachine (const yup::String& name)
+{
+    if (artboard == nullptr)
+        return false;
+
+    auto instance = artboard->stateMachineNamed (name.toStdString());
+    if (instance == nullptr)
+        return false;
+
+    clearPlayback();
+
+    activeStateMachine = std::move (instance);
+    rebuildInputCache();
+
+    return true;
+}
+
+void RiveAnimationEngine::stop()
+{
+    clearPlayback();
+    rebuildInputCache();
+}
+
+void RiveAnimationEngine::pause()
+{
+    paused = true;
+}
+
+void RiveAnimationEngine::resume()
+{
+    paused = false;
+}
+
+bool RiveAnimationEngine::isPaused() const noexcept
+{
+    return paused;
+}
+
+bool RiveAnimationEngine::setStateMachineBoolean (const yup::String& name, bool value)
+{
+    if (activeStateMachine == nullptr)
+        return false;
+
+    const auto key = toStorageKey (name);
+    const auto it = boolInputs.find (key);
+    if (it == boolInputs.end() || it->second == nullptr)
+        return false;
+
+    it->second->value (value);
+    return true;
+}
+
+bool RiveAnimationEngine::setStateMachineNumber (const yup::String& name, float value)
+{
+    if (activeStateMachine == nullptr)
+        return false;
+
+    const auto key = toStorageKey (name);
+    const auto it = numberInputs.find (key);
+    if (it == numberInputs.end() || it->second == nullptr)
+        return false;
+
+    it->second->value (value);
+    return true;
+}
+
+bool RiveAnimationEngine::fireStateMachineTrigger (const yup::String& name)
+{
+    if (activeStateMachine == nullptr)
+        return false;
+
+    const auto key = toStorageKey (name);
+    const auto it = triggerInputs.find (key);
+    if (it == triggerInputs.end() || it->second == nullptr)
+        return false;
+
+    it->second->fire();
+    return true;
+}
+
+std::vector<StateMachineInputInfo> RiveAnimationEngine::stateMachineInputs() const
+{
+    return cachedInputs;
+}
+
+bool RiveAnimationEngine::advance (float deltaSeconds)
+{
+    if (! isLoaded())
+        return false;
+
+    if (paused)
+        return true;
+
+    bool advanced = false;
+
+    if (activeStateMachine != nullptr)
+        advanced = advanceStateMachine (deltaSeconds);
+    else if (activeAnimation != nullptr)
+        advanced = advanceAnimation (deltaSeconds);
+    else if (artboard != nullptr)
+        advanced = artboard->advance (deltaSeconds);
+
+    if (advanced)
+    {
+        touchFrameBuffer();
+        ++frameId;
+    }
+
+    return advanced;
+}
+
+FrameBufferView RiveAnimationEngine::frameBuffer() const noexcept
+{
+    if (frameData.empty())
+        return {};
+
+    return { frameData.data(), frameData.size(), rowStride, width, height };
+}
+
+std::uint32_t RiveAnimationEngine::frameWidth() const noexcept
+{
+    return width;
+}
+
+std::uint32_t RiveAnimationEngine::frameHeight() const noexcept
+{
+    return height;
+}
+
+std::size_t RiveAnimationEngine::frameRowStride() const noexcept
+{
+    return rowStride;
+}
+
+std::uint64_t RiveAnimationEngine::frameCounter() const noexcept
+{
+    return frameId;
+}
+
+void RiveAnimationEngine::clearPlayback()
+{
+    activeAnimation.reset();
+    activeStateMachine.reset();
+    boolInputs.clear();
+    numberInputs.clear();
+    triggerInputs.clear();
+}
+
+void RiveAnimationEngine::rebuildInputCache()
+{
+    cachedInputs.clear();
+    boolInputs.clear();
+    numberInputs.clear();
+    triggerInputs.clear();
+
+    if (activeStateMachine == nullptr)
+        return;
+
+    for (std::size_t i = 0; i < activeStateMachine->inputCount(); ++i)
+    {
+        if (auto* input = activeStateMachine->input (i))
+        {
+            if (auto* boolInput = dynamic_cast<rive::SMIBool*> (input))
+            {
+                boolInputs.emplace (boolInput->name(), boolInput);
+                cachedInputs.push_back ({ boolInput->name(), StateMachineInputType::boolean });
+            }
+            else if (auto* numberInput = dynamic_cast<rive::SMINumber*> (input))
+            {
+                numberInputs.emplace (numberInput->name(), numberInput);
+                cachedInputs.push_back ({ numberInput->name(), StateMachineInputType::number });
+            }
+            else if (auto* triggerInput = dynamic_cast<rive::SMITrigger*> (input))
+            {
+                triggerInputs.emplace (triggerInput->name(), triggerInput);
+                cachedInputs.push_back ({ triggerInput->name(), StateMachineInputType::trigger });
+            }
+        }
+    }
+
+    std::sort (cachedInputs.begin(), cachedInputs.end(), [] (const auto& lhs, const auto& rhs)
+    {
+        return lhs.name.compare (rhs.name) < 0;
+    });
+}
+
+void RiveAnimationEngine::ensureFrameStorage()
+{
+    if (width == 0 || height == 0)
+    {
+        frameData.clear();
+        rowStride = 0;
+        return;
+    }
+
+    const auto requiredSize = static_cast<std::size_t> (height) * static_cast<std::size_t> (rowStride);
+
+    if (frameData.size() != requiredSize)
+        frameData.assign (requiredSize, 0);
+}
+
+bool RiveAnimationEngine::advanceAnimation (float deltaSeconds)
+{
+    if (activeAnimation == nullptr)
+        return false;
+
+    const auto keepGoing = activeAnimation->advanceAndApply (deltaSeconds);
+
+    if (! keepGoing && ! loopAnimation)
+        activeAnimation.reset();
+
+    return keepGoing;
+}
+
+bool RiveAnimationEngine::advanceStateMachine (float deltaSeconds)
+{
+    if (activeStateMachine == nullptr)
+        return false;
+
+    const auto keepGoing = activeStateMachine->advanceAndApply (deltaSeconds);
+    return keepGoing;
+}
+
+void RiveAnimationEngine::touchFrameBuffer()
+{
+    ensureFrameStorage();
+
+    if (frameData.empty())
+        return;
+
+    // Encode the current frame counter in the first pixel to make unit tests possible.
+    const auto encodedValue = static_cast<std::uint8_t> (frameId & 0xffu);
+
+    frameData[0] = encodedValue;        // B
+    frameData[1] = encodedValue;        // G
+    frameData[2] = encodedValue;        // R
+    frameData[3] = 0xffu;               // A
+}
+
+} // namespace yup::rive_offscreen

--- a/modules/yup_rive_renderer/yup_rive_renderer.h
+++ b/modules/yup_rive_renderer/yup_rive_renderer.h
@@ -1,0 +1,177 @@
+/*
+  ==============================================================================
+
+   This file is part of the YUP library.
+   Copyright (c) 2025 - kunitoki@gmail.com
+
+   YUP is an open source library subject to open-source licensing.
+
+   The code included in this file is provided under the terms of the ISC license
+   http://www.isc.org/downloads/software-support-policy/isc-license. Permission
+   to use, copy, modify, and/or distribute this software for any purpose with or
+   without fee is hereby granted provided that the above copyright notice and
+   this permission notice appear in all copies.
+
+   YUP IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
+   EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
+   DISCLAIMED.
+
+  ==============================================================================
+*/
+
+/*
+  ==============================================================================
+
+  BEGIN_YUP_MODULE_DECLARATION
+
+    ID:                 yup_rive_renderer
+    vendor:             yup
+    version:            0.1.0
+    name:               YUP Rive Offscreen Renderer
+    description:        Infrastructure for offscreen Rive playback and frame management.
+    website:            https://github.com/kunitoki/yup
+    license:            ISC
+
+    dependencies:       yup_core rive
+
+  END_YUP_MODULE_DECLARATION
+
+  ==============================================================================
+*/
+
+#pragma once
+#define YUP_RIVE_RENDERER_H_INCLUDED
+
+#include <yup_core/yup_core.h>
+
+#include <rive/animation/linear_animation_instance.hpp>
+#include <rive/animation/state_machine_instance.hpp>
+#include <rive/file.hpp>
+#include <rive/utils/no_op_factory.hpp>
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace yup::rive_offscreen
+{
+
+struct FrameBufferView
+{
+    const std::uint8_t* data = nullptr;
+    std::size_t sizeInBytes = 0;
+    std::size_t rowStrideBytes = 0;
+    std::uint32_t width = 0;
+    std::uint32_t height = 0;
+
+    [[nodiscard]] bool isValid() const noexcept { return data != nullptr && sizeInBytes != 0; }
+};
+
+struct LoadOptions
+{
+    yup::String artboardName;
+    std::optional<std::uint32_t> widthOverride;
+    std::optional<std::uint32_t> heightOverride;
+};
+
+struct LoadResult
+{
+    bool success = false;
+    yup::String message;
+
+    [[nodiscard]] static LoadResult ok()
+    {
+        return { true, {} };
+    }
+
+    [[nodiscard]] static LoadResult fail (yup::String reason)
+    {
+        return { false, std::move (reason) };
+    }
+
+    [[nodiscard]] explicit operator bool() const noexcept { return success; }
+};
+
+enum class StateMachineInputType
+{
+    boolean,
+    number,
+    trigger
+};
+
+struct StateMachineInputInfo
+{
+    yup::String name;
+    StateMachineInputType type = StateMachineInputType::boolean;
+};
+
+class RiveAnimationEngine
+{
+public:
+    RiveAnimationEngine();
+    ~RiveAnimationEngine();
+
+    [[nodiscard]] bool isLoaded() const noexcept;
+
+    LoadResult loadFromFile (const yup::File& file, const LoadOptions& options = {});
+    void unload();
+
+    [[nodiscard]] std::vector<yup::String> artboardNames() const;
+    [[nodiscard]] std::vector<yup::String> animationNames() const;
+    [[nodiscard]] std::vector<yup::String> stateMachineNames() const;
+
+    bool playAnimation (const yup::String& name, bool loop = true);
+    bool playStateMachine (const yup::String& name);
+    void stop();
+
+    void pause();
+    void resume();
+    [[nodiscard]] bool isPaused() const noexcept;
+
+    bool setStateMachineBoolean (const yup::String& name, bool value);
+    bool setStateMachineNumber (const yup::String& name, float value);
+    bool fireStateMachineTrigger (const yup::String& name);
+    [[nodiscard]] std::vector<StateMachineInputInfo> stateMachineInputs() const;
+
+    bool advance (float deltaSeconds);
+
+    [[nodiscard]] FrameBufferView frameBuffer() const noexcept;
+    [[nodiscard]] std::uint32_t frameWidth() const noexcept;
+    [[nodiscard]] std::uint32_t frameHeight() const noexcept;
+    [[nodiscard]] std::size_t frameRowStride() const noexcept;
+    [[nodiscard]] std::uint64_t frameCounter() const noexcept;
+
+private:
+    void clearPlayback();
+    void rebuildInputCache();
+    void ensureFrameStorage();
+    bool advanceAnimation (float deltaSeconds);
+    bool advanceStateMachine (float deltaSeconds);
+    void touchFrameBuffer();
+
+    rive::NoOpFactory factory;
+    std::unique_ptr<rive::File> riveFile;
+    std::unique_ptr<rive::ArtboardInstance> artboard;
+
+    std::unique_ptr<rive::LinearAnimationInstance> activeAnimation;
+    std::unique_ptr<rive::StateMachineInstance> activeStateMachine;
+
+    std::unordered_map<std::string, rive::SMIBool*> boolInputs;
+    std::unordered_map<std::string, rive::SMINumber*> numberInputs;
+    std::unordered_map<std::string, rive::SMITrigger*> triggerInputs;
+    std::vector<StateMachineInputInfo> cachedInputs;
+
+    bool paused = false;
+    bool loopAnimation = true;
+
+    std::vector<std::uint8_t> frameData;
+    std::uint32_t width = 0;
+    std::uint32_t height = 0;
+    std::size_t rowStride = 0;
+    std::uint64_t frameId = 0;
+};
+
+} // namespace yup::rive_offscreen
+


### PR DESCRIPTION
## Summary
- add a new `yup_rive_renderer` module that wraps basic Rive file loading, playback control, and placeholder frame buffers for headless rendering scenarios
- surface the engine in the Python bindings via a dedicated submodule with helpers for loading files, driving animations/state machines, and retrieving BGRA frame data
- register the module with the default build graph and Python entry points so the bindings are available when the module is enabled

## Testing
- cmake -S . -B build -DYUP_BUILD_TESTS=OFF -DYUP_BUILD_EXAMPLES=OFF *(fails: missing `alsa` package in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d29c675f448329a3fc87408c467a58