### PR TITLE
Add initial Rive renderer scaffolding and bindings

### DIFF
--- a/cmake/yup_modules.cmake
+++ b/cmake/yup_modules.cmake
@@ -639,6 +639,9 @@ macro (yup_add_default_modules modules_path)
     yup_add_module (${modules_path}/modules/yup_graphics "${modules_definitions}" ${modules_group})
     add_library (yup::yup_graphics ALIAS yup_graphics)
 
+    yup_add_module (${modules_path}/modules/yup_rive_renderer "${modules_definitions}" ${modules_group})
+    add_library (yup::yup_rive_renderer ALIAS yup_rive_renderer)
+
     yup_add_module (${modules_path}/modules/yup_gui "${modules_definitions}" ${modules_group})
     add_library (yup::yup_gui ALIAS yup_gui)
 

--- a/modules/yup_python/bindings/yup_YupRiveRenderer_bindings.cpp
+++ b/modules/yup_python/bindings/yup_YupRiveRenderer_bindings.cpp
@@ -1,0 +1,101 @@
+/*
+  ==============================================================================
+
+   This file is part of the YUP library.
+ Copyright (c) 2025 - kunitoki@gmail.com
+
+   YUP is an open source library subject to open-source licensing.
+
+   The code included in this file is provided under the terms of the ISC license
+   http://www.isc.org/downloads/software-support-policy/isc-license. Permission
+   to use, copy, modify, and/or distribute this software for any purpose with or
+   without fee is hereby granted provided that the above copyright notice and
+   this permission notice appear in all copies.
+
+   YUP IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
+   EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
+   DISCLAIMED.
+
+  ==============================================================================
+*/
+
+#include "yup_YupRiveRenderer_bindings.h"
+
+#include <yup_rive_renderer/yup_rive_renderer.h>
+
+#include "../utilities/yup_NumPyUtilities.h"
+
+#include <algorithm>
+#include <array>
+#include <cstring>
+
+#include <yup_core/file/yup_File.h>
+
+namespace yup::Bindings
+{
+namespace
+{
+pybind11::array makeFrameArray (yup::rive_renderer::RiveRenderer& renderer)
+{
+    const auto width = renderer.width();
+    const auto height = renderer.height();
+
+    if (width == 0 || height == 0)
+        return pybind11::array (pybind11::dtype::of<uint8>(), { 0, 0, 4 });
+
+    auto data = renderer.pixelData();
+    const auto shape = std::array<pybind11::ssize_t, 3> {
+        static_cast<pybind11::ssize_t> (height),
+        static_cast<pybind11::ssize_t> (width),
+        4
+    };
+
+    const auto strides = std::array<pybind11::ssize_t, 3> {
+        static_cast<pybind11::ssize_t> (width * 4),
+        4,
+        1
+    };
+
+    pybind11::array result (pybind11::dtype::of<uint8>(), shape, strides);
+    const auto bytesToCopy = std::min (static_cast<size_t> (result.nbytes()), data.size());
+    std::memcpy (result.mutable_data(), data.data(), bytesToCopy);
+    return result;
+}
+}
+
+void registerYupRiveRendererBindings (pybind11::module_& module)
+{
+    namespace py = pybind11;
+    using namespace yup::rive_renderer;
+
+    py::class_<RiveRenderer> (module, "RiveRenderer")
+        .def (py::init<>())
+        .def ("load", [] (RiveRenderer& self, const std::string& path) {
+            return self.load (yup::File (path));
+        })
+        .def ("load_bytes", [] (RiveRenderer& self, py::bytes bytes) {
+            const auto buffer = bytes.cast<std::string>();
+            return self.loadFromData (Span<const uint8> {
+                reinterpret_cast<const uint8*> (buffer.data()),
+                static_cast<size_t> (buffer.size()) });
+        })
+        .def ("animations", &RiveRenderer::animationNames)
+        .def ("state_machines", &RiveRenderer::stateMachineNames)
+        .def ("play", &RiveRenderer::playAnimation, py::arg ("name"), py::arg ("loop") = true)
+        .def ("play_state_machine", &RiveRenderer::playStateMachine)
+        .def ("stop", &RiveRenderer::stop)
+        .def ("pause", &RiveRenderer::pause)
+        .def ("resume", &RiveRenderer::resume)
+        .def ("advance", &RiveRenderer::advance, py::arg ("dt"), py::call_guard<py::gil_scoped_release>())
+        .def ("frame", [] (RiveRenderer& self) { return makeFrameArray (self); })
+        .def_property_readonly ("width", &RiveRenderer::width)
+        .def_property_readonly ("height", &RiveRenderer::height)
+        .def_property_readonly ("current_animation", &RiveRenderer::currentAnimation)
+        .def_property_readonly ("current_state_machine", &RiveRenderer::currentStateMachine)
+        .def ("set_number", &RiveRenderer::setNumberInput)
+        .def ("set_bool", &RiveRenderer::setBooleanInput)
+        .def ("fire_trigger", &RiveRenderer::fireTrigger)
+        .def ("render", &RiveRenderer::renderFrame, py::call_guard<py::gil_scoped_release>());
+}
+
+} // namespace yup::Bindings

--- a/modules/yup_python/bindings/yup_YupRiveRenderer_bindings.h
+++ b/modules/yup_python/bindings/yup_YupRiveRenderer_bindings.h
@@ -1,0 +1,33 @@
+/*
+  ==============================================================================
+
+   This file is part of the YUP library.
+   Copyright (c) 2025 - kunitoki@gmail.com
+
+   YUP is an open source library subject to open-source licensing.
+
+   The code included in this file is provided under the terms of the ISC license
+   http://www.isc.org/downloads/software-support-policy/isc-license. Permission
+   to use, copy, modify, and/or distribute this software for any purpose with or
+   without fee is hereby granted provided that the above copyright notice and
+   this permission notice appear in all copies.
+
+   YUP IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
+   EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
+   DISCLAIMED.
+
+  ==============================================================================
+*/
+
+#pragma once
+
+#if ! YUP_MODULE_AVAILABLE_yup_rive_renderer
+#   error "Rive renderer module unavailable"
+#endif
+
+#include "../utilities/yup_PyBind11Includes.h"
+
+namespace yup::Bindings
+{
+void registerYupRiveRendererBindings (pybind11::module_& module);
+}

--- a/modules/yup_python/modules/yup_YupMain_module.cpp
+++ b/modules/yup_python/modules/yup_YupMain_module.cpp
@@ -38,6 +38,10 @@
 #include "../bindings/yup_YupGraphics_bindings.h"
 #endif
 
+#if YUP_MODULE_AVAILABLE_yup_rive_renderer
+#include "../bindings/yup_YupRiveRenderer_bindings.h"
+#endif
+
 #if YUP_MODULE_AVAILABLE_yup_gui
 #include "../bindings/yup_YupGui_bindings.h"
 #endif
@@ -90,6 +94,10 @@ PYBIND11_MODULE (YUP_PYTHON_MODULE_NAME, m)
 
 #if YUP_MODULE_AVAILABLE_yup_graphics
     yup::Bindings::registerYupGraphicsBindings (m);
+#endif
+
+#if YUP_MODULE_AVAILABLE_yup_rive_renderer
+    yup::Bindings::registerYupRiveRendererBindings (m);
 #endif
 
 #if YUP_MODULE_AVAILABLE_yup_gui

--- a/modules/yup_rive_renderer/engine/yup_RiveAnimationEngine.cpp
+++ b/modules/yup_rive_renderer/engine/yup_RiveAnimationEngine.cpp
@@ -1,0 +1,296 @@
+/*
+  ==============================================================================
+
+   This file is part of the YUP library.
+   Copyright (c) 2025 - kunitoki@gmail.com
+
+   YUP is an open source library subject to open-source licensing.
+
+   The code included in this file is provided under the terms of the ISC license
+   http://www.isc.org/downloads/software-support-policy/isc-license. Permission
+   to use, copy, modify, and/or distribute this software for any purpose with or
+   without fee is hereby granted provided that the above copyright notice and
+   this permission notice appear in all copies.
+
+   YUP IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
+   EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
+   DISCLAIMED.
+
+  ==============================================================================
+*/
+
+#include "yup_RiveAnimationEngine.h"
+
+#include <rive/artboard.hpp>
+#include <rive/animation/linear_animation_instance.hpp>
+#include <rive/animation/loop.hpp>
+#include <rive/animation/state_machine_instance.hpp>
+#include <rive/animation/state_machine_input_instance.hpp>
+#include <rive/file.hpp>
+
+#include <yup_core/file/yup_File.h>
+#include <yup_core/memory/yup_MemoryBlock.h>
+
+namespace yup::rive_renderer
+{
+
+namespace
+{
+std::vector<std::string> collectStateMachineNames (const rive::ArtboardInstance& artboard)
+{
+    std::vector<std::string> names;
+    const auto count = artboard.stateMachineCount();
+    names.reserve (count);
+
+    for (size_t i = 0; i < count; ++i)
+    {
+        names.push_back (artboard.stateMachineNameAt (i));
+    }
+
+    return names;
+}
+
+} // namespace
+
+RiveAnimationEngine::~RiveAnimationEngine() = default;
+
+bool RiveAnimationEngine::loadFromFile (const File& file,
+                                        rive::Factory& factory,
+                                        const LoadOptions& options)
+{
+    if (! file.existsAsFile())
+        return false;
+
+    auto input = file.createInputStream();
+    if (input == nullptr || ! input->openedOk())
+        return false;
+
+    MemoryBlock block;
+    input->readIntoMemoryBlock (block);
+    return loadFromData ({ static_cast<const uint8*> (block.getData()), block.getSize() }, factory, options);
+}
+
+bool RiveAnimationEngine::loadFromData (Span<const uint8> data,
+                                        rive::Factory& factory,
+                                        const LoadOptions& options)
+{
+    rive::ImportResult importResult = rive::ImportResult::malformed;
+    auto file = rive::File::import ({ data.data(), data.size() }, &factory, &importResult);
+
+    if (importResult != rive::ImportResult::success || file == nullptr)
+        return false;
+
+    riveFile = std::move (file);
+    if (! selectArtboard (options))
+    {
+        riveFile.reset();
+        return false;
+    }
+
+    resetPlaybackState();
+    return true;
+}
+
+bool RiveAnimationEngine::isLoaded() const noexcept
+{
+    return riveFile != nullptr && artboardInstance != nullptr;
+}
+
+std::vector<std::string> RiveAnimationEngine::animationNames() const
+{
+    if (! isLoaded())
+        return {};
+
+    std::vector<std::string> names;
+    const auto count = artboardInstance->animationCount();
+    names.reserve (count);
+
+    for (size_t i = 0; i < count; ++i)
+        names.push_back (artboardInstance->animationNameAt (i));
+
+    return names;
+}
+
+std::vector<std::string> RiveAnimationEngine::stateMachineNames() const
+{
+    if (! isLoaded())
+        return {};
+
+    return collectStateMachineNames (*artboardInstance);
+}
+
+bool RiveAnimationEngine::playAnimation (const std::string& name, bool loop)
+{
+    if (! isLoaded())
+        return false;
+
+    auto instance = artboardInstance->animationNamed (name);
+    if (instance == nullptr)
+        return false;
+
+    animationInstance = std::move (instance);
+    loopAnimation = loop;
+    activeAnimationName = name;
+    activeStateMachineName.reset();
+    stateMachineInstance.reset();
+
+    animationInstance->loopValue (loop ? static_cast<int> (rive::Loop::loop)
+                                       : static_cast<int> (rive::Loop::oneShot));
+    animationInstance->reset (1.0f);
+
+    return true;
+}
+
+bool RiveAnimationEngine::playStateMachine (const std::string& name)
+{
+    if (! isLoaded())
+        return false;
+
+    auto instance = artboardInstance->stateMachineNamed (name);
+    if (instance == nullptr)
+        return false;
+
+    stateMachineInstance = std::move (instance);
+    activeStateMachineName = name;
+    activeAnimationName.reset();
+    animationInstance.reset();
+
+    return true;
+}
+
+void RiveAnimationEngine::stop()
+{
+    animationInstance.reset();
+    stateMachineInstance.reset();
+    activeAnimationName.reset();
+    activeStateMachineName.reset();
+}
+
+bool RiveAnimationEngine::advance (float deltaSeconds)
+{
+    if (! isLoaded() || isPaused)
+        return false;
+
+    bool didAdvance = false;
+
+    if (animationInstance != nullptr)
+    {
+        const auto keepGoing = animationInstance->advanceAndApply (deltaSeconds);
+        didAdvance = true;
+
+        if (! keepGoing && ! loopAnimation)
+        {
+            animationInstance.reset();
+            activeAnimationName.reset();
+        }
+    }
+
+    if (stateMachineInstance != nullptr)
+    {
+        didAdvance |= stateMachineInstance->advanceAndApply (deltaSeconds);
+    }
+
+    if (didAdvance)
+    {
+        artboardInstance->advance (deltaSeconds);
+    }
+
+    return didAdvance;
+}
+
+bool RiveAnimationEngine::setNumberInput (const std::string& name, float value)
+{
+    if (stateMachineInstance == nullptr)
+        return false;
+
+    if (auto* numberInput = stateMachineInstance->getNumber (name))
+    {
+        numberInput->value (value);
+        return true;
+    }
+
+    return false;
+}
+
+bool RiveAnimationEngine::setBooleanInput (const std::string& name, bool value)
+{
+    if (stateMachineInstance == nullptr)
+        return false;
+
+    if (auto* boolInput = stateMachineInstance->getBool (name))
+    {
+        boolInput->value (value);
+        return true;
+    }
+
+    if (value)
+    {
+        if (auto* trigger = stateMachineInstance->getTrigger (name))
+        {
+            trigger->fire();
+            return true;
+        }
+    }
+
+    return false;
+}
+
+bool RiveAnimationEngine::fireTrigger (const std::string& name)
+{
+    if (stateMachineInstance == nullptr)
+        return false;
+
+    if (auto* trigger = stateMachineInstance->getTrigger (name))
+    {
+        trigger->fire();
+        return true;
+    }
+
+    return false;
+}
+
+std::pair<float, float> RiveAnimationEngine::artboardDimensions() const noexcept
+{
+    if (! isLoaded())
+        return { 0.0f, 0.0f };
+
+    const auto width = artboardInstance->layoutWidth();
+    const auto height = artboardInstance->layoutHeight();
+    return { width, height };
+}
+
+bool RiveAnimationEngine::selectArtboard (const LoadOptions& options)
+{
+    if (riveFile == nullptr)
+        return false;
+
+    std::unique_ptr<rive::ArtboardInstance> instance;
+
+    if (! options.artboardName.empty())
+        instance = riveFile->artboardNamed (options.artboardName);
+
+    if (instance == nullptr)
+        instance = riveFile->artboardDefault();
+
+    if (instance == nullptr && riveFile->artboardCount() > 0)
+        instance = riveFile->artboardAt (0);
+
+    if (instance == nullptr)
+        return false;
+
+    artboardInstance = std::move (instance);
+    artboardInstance->advance (0.0f);
+    return true;
+}
+
+void RiveAnimationEngine::resetPlaybackState()
+{
+    animationInstance.reset();
+    stateMachineInstance.reset();
+    activeAnimationName.reset();
+    activeStateMachineName.reset();
+    loopAnimation = true;
+    isPaused = false;
+}
+
+} // namespace yup::rive_renderer

--- a/modules/yup_rive_renderer/engine/yup_RiveAnimationEngine.h
+++ b/modules/yup_rive_renderer/engine/yup_RiveAnimationEngine.h
@@ -1,0 +1,136 @@
+/*
+  ==============================================================================
+
+   This file is part of the YUP library.
+   Copyright (c) 2025 - kunitoki@gmail.com
+
+   YUP is an open source library subject to open-source licensing.
+
+   The code included in this file is provided under the terms of the ISC license
+   http://www.isc.org/downloads/software-support-policy/isc-license. Permission
+   to use, copy, modify, and/or distribute this software for any purpose with or
+   without fee is hereby granted provided that the above copyright notice and
+   this permission notice appear in all copies.
+
+   YUP IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
+   EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
+   DISCLAIMED.
+
+  ==============================================================================
+*/
+
+#pragma once
+
+#include <optional>
+#include <string>
+#include <vector>
+
+#include <yup_core/yup_core.h>
+
+namespace rive
+{
+class ArtboardInstance;
+class Factory;
+class LinearAnimationInstance;
+class StateMachineInstance;
+}
+
+namespace yup
+{
+class File;
+}
+
+namespace yup::rive_renderer
+{
+
+/** Manages the lifecycle of a Rive file, including loading, animation control,
+    state machine interaction and frame advancement. */
+class YUP_API RiveAnimationEngine
+{
+public:
+    struct LoadOptions
+    {
+        std::string artboardName; ///< Optional artboard name to load.
+    };
+
+    RiveAnimationEngine() = default;
+    ~RiveAnimationEngine();
+
+    RiveAnimationEngine (RiveAnimationEngine&&) noexcept = default;
+    RiveAnimationEngine& operator= (RiveAnimationEngine&&) noexcept = default;
+
+    RiveAnimationEngine (const RiveAnimationEngine&) = delete;
+    RiveAnimationEngine& operator= (const RiveAnimationEngine&) = delete;
+
+    /** Loads a Rive file from disk using the provided factory. */
+    bool loadFromFile (const File& file,
+                       rive::Factory& factory,
+                       const LoadOptions& options = {});
+
+    /** Loads a Rive file from a memory buffer. */
+    bool loadFromData (Span<const uint8> data,
+                       rive::Factory& factory,
+                       const LoadOptions& options = {});
+
+    /** Returns true when a file and artboard have been loaded successfully. */
+    bool isLoaded() const noexcept;
+
+    /** Returns the active artboard instance. */
+    rive::ArtboardInstance* artboard() noexcept { return artboardInstance.get(); }
+    const rive::ArtboardInstance* artboard() const noexcept { return artboardInstance.get(); }
+
+    /** Returns a snapshot of animation names available on the artboard. */
+    std::vector<std::string> animationNames() const;
+
+    /** Returns a snapshot of state machine names available on the artboard. */
+    std::vector<std::string> stateMachineNames() const;
+
+    /** Starts playing a linear animation by name. */
+    bool playAnimation (const std::string& name, bool loop);
+
+    /** Starts a state machine by name. */
+    bool playStateMachine (const std::string& name);
+
+    /** Stops any running animation or state machine. */
+    void stop();
+
+    /** Pauses the currently active animation or state machine. */
+    void setPaused (bool shouldPause) noexcept { isPaused = shouldPause; }
+    bool paused() const noexcept { return isPaused; }
+
+    /** Advances the animation/state-machine by the provided delta time. */
+    bool advance (float deltaSeconds);
+
+    /** Sets the value of a numerical state machine input. */
+    bool setNumberInput (const std::string& name, float value);
+
+    /** Sets the value of a boolean state machine input. */
+    bool setBooleanInput (const std::string& name, bool value);
+
+    /** Fires a trigger input on the active state machine. */
+    bool fireTrigger (const std::string& name);
+
+    /** Returns the width/height from the artboard layout if available. */
+    std::pair<float, float> artboardDimensions() const noexcept;
+
+    /** Returns the name of the currently playing animation, if any. */
+    const std::optional<std::string>& currentAnimation() const noexcept { return activeAnimationName; }
+
+    /** Returns the name of the currently active state machine, if any. */
+    const std::optional<std::string>& currentStateMachine() const noexcept { return activeStateMachineName; }
+
+private:
+    bool selectArtboard (const LoadOptions& options);
+    void resetPlaybackState();
+
+    std::unique_ptr<rive::File> riveFile;
+    std::unique_ptr<rive::ArtboardInstance> artboardInstance;
+    std::unique_ptr<rive::LinearAnimationInstance> animationInstance;
+    std::unique_ptr<rive::StateMachineInstance> stateMachineInstance;
+    std::optional<std::string> activeAnimationName;
+    std::optional<std::string> activeStateMachineName;
+    bool loopAnimation = true;
+    bool isPaused = false;
+};
+
+} // namespace yup::rive_renderer

--- a/modules/yup_rive_renderer/renderer/yup_RiveOffscreenRenderer.cpp
+++ b/modules/yup_rive_renderer/renderer/yup_RiveOffscreenRenderer.cpp
@@ -1,0 +1,129 @@
+/*
+  ==============================================================================
+
+   This file is part of the YUP library.
+   Copyright (c) 2025 - kunitoki@gmail.com
+
+   YUP is an open source library subject to open-source licensing.
+
+   The code included in this file is provided under the terms of the ISC license
+   http://www.isc.org/downloads/software-support-policy/isc-license. Permission
+   to use, copy, modify, and/or distribute this software for any purpose with or
+   without fee is hereby granted provided that the above copyright notice and
+   this permission notice appear in all copies.
+
+   YUP IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
+   EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
+   DISCLAIMED.
+
+  ==============================================================================
+*/
+
+#include "yup_RiveOffscreenRenderer.h"
+
+#include <algorithm>
+
+#include <rive/artboard.hpp>
+#include <rive/renderer.hpp>
+
+namespace yup::rive_renderer
+{
+
+namespace
+{
+GraphicsContext::Options makeContextOptions (const RiveOffscreenRenderer::Options& rendererOptions)
+{
+    GraphicsContext::Options opts;
+    opts.allowHeadlessRendering = true;
+    opts.enableReadPixels = rendererOptions.enableReadableFramebuffer;
+    opts.readableFramebuffer = rendererOptions.enableReadableFramebuffer;
+    opts.retinaDisplay = false;
+    return opts;
+}
+}
+
+RiveOffscreenRenderer::RiveOffscreenRenderer (Options options)
+    : options (options)
+{
+    resize (options.width, options.height);
+    ensureContext();
+}
+
+RiveOffscreenRenderer::~RiveOffscreenRenderer() = default;
+
+RiveOffscreenRenderer::RiveOffscreenRenderer (RiveOffscreenRenderer&& other) noexcept = default;
+RiveOffscreenRenderer& RiveOffscreenRenderer::operator= (RiveOffscreenRenderer&& other) noexcept = default;
+
+rive::Factory* RiveOffscreenRenderer::factory() const noexcept
+{
+    return graphicsContext != nullptr ? graphicsContext->factory() : nullptr;
+}
+
+void RiveOffscreenRenderer::resize (uint32_t newWidth, uint32_t newHeight)
+{
+    renderWidth = newWidth;
+    renderHeight = newHeight;
+    allocateCpuBuffer();
+
+    if (graphicsContext != nullptr)
+        riveRenderer = graphicsContext->makeRenderer (static_cast<int> (renderWidth), static_cast<int> (renderHeight));
+}
+
+void RiveOffscreenRenderer::clear()
+{
+    std::fill (cpuBuffer.begin(), cpuBuffer.end(), static_cast<uint8> (0));
+}
+
+Span<const uint8> RiveOffscreenRenderer::pixelData() const noexcept
+{
+    return { cpuBuffer.data(), cpuBuffer.size() };
+}
+
+Span<uint8> RiveOffscreenRenderer::mutablePixelData() noexcept
+{
+    return { cpuBuffer.data(), cpuBuffer.size() };
+}
+
+bool RiveOffscreenRenderer::render (rive::ArtboardInstance& artboard)
+{
+    if (! ensureContext() || riveRenderer == nullptr)
+        return false;
+
+    artboard.draw (riveRenderer.get());
+    return false;
+}
+
+void RiveOffscreenRenderer::allocateCpuBuffer()
+{
+    if (renderWidth == 0 || renderHeight == 0)
+    {
+        cpuBuffer.clear();
+        return;
+    }
+
+    const auto size = static_cast<size_t> (renderWidth) * static_cast<size_t> (renderHeight) * bytesPerPixel();
+    cpuBuffer.resize (size);
+    clear();
+}
+
+bool RiveOffscreenRenderer::ensureContext()
+{
+    if (graphicsContext != nullptr)
+        return true;
+
+    auto ctxOptions = makeContextOptions (options);
+
+#if YUP_WINDOWS
+    graphicsContext = GraphicsContext::createContext (GraphicsContext::Direct3D, ctxOptions);
+#endif
+
+    if (graphicsContext == nullptr)
+        graphicsContext = GraphicsContext::createContext (GraphicsContext::Headless, ctxOptions);
+
+    if (graphicsContext != nullptr)
+        riveRenderer = graphicsContext->makeRenderer (static_cast<int> (renderWidth), static_cast<int> (renderHeight));
+
+    return graphicsContext != nullptr;
+}
+
+} // namespace yup::rive_renderer

--- a/modules/yup_rive_renderer/renderer/yup_RiveOffscreenRenderer.h
+++ b/modules/yup_rive_renderer/renderer/yup_RiveOffscreenRenderer.h
@@ -1,0 +1,108 @@
+/*
+  ==============================================================================
+
+   This file is part of the YUP library.
+   Copyright (c) 2025 - kunitoki@gmail.com
+
+   YUP is an open source library subject to open-source licensing.
+
+   The code included in this file is provided under the terms of the ISC license
+   http://www.isc.org/downloads/software-support-policy/isc-license. Permission
+   to use, copy, modify, and/or distribute this software for any purpose with or
+   without fee is hereby granted provided that the above copyright notice and
+   this permission notice appear in all copies.
+
+   YUP IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
+   EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
+   DISCLAIMED.
+
+  ==============================================================================
+*/
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include <yup_core/yup_core.h>
+#include <yup_graphics/context/yup_GraphicsContext.h>
+
+namespace rive
+{
+class ArtboardInstance;
+class Factory;
+}
+
+namespace yup::rive_renderer
+{
+
+/** Offscreen renderer responsible for preparing frame buffers suitable for
+    downstream processing.
+
+    The current implementation focuses on providing an allocation and life-cycle
+    for the backing buffers while deferring platform specific GPU composition to
+    future iterations. */
+class YUP_API RiveOffscreenRenderer
+{
+public:
+    struct Options
+    {
+        uint32_t width = 0;
+        uint32_t height = 0;
+        bool enableReadableFramebuffer = true;
+    };
+
+    explicit RiveOffscreenRenderer (Options options = {});
+    ~RiveOffscreenRenderer();
+
+    RiveOffscreenRenderer (const RiveOffscreenRenderer&) = delete;
+    RiveOffscreenRenderer& operator= (const RiveOffscreenRenderer&) = delete;
+
+    RiveOffscreenRenderer (RiveOffscreenRenderer&&) noexcept;
+    RiveOffscreenRenderer& operator= (RiveOffscreenRenderer&&) noexcept;
+
+    /** Returns the factory used for importing Rive files. */
+    rive::Factory* factory() const noexcept;
+
+    /** Resizes the output buffer, invalidating previously captured data. */
+    void resize (uint32_t newWidth, uint32_t newHeight);
+
+    /** Clears the CPU side buffer. */
+    void clear();
+
+    /** Returns the width of the current render target. */
+    uint32_t width() const noexcept { return renderWidth; }
+
+    /** Returns the height of the current render target. */
+    uint32_t height() const noexcept { return renderHeight; }
+
+    /** Returns the bytes per pixel for the output format (BGRA8). */
+    static constexpr uint32_t bytesPerPixel() noexcept { return 4; }
+
+    /** Returns a read-only view over the CPU buffer. */
+    Span<const uint8> pixelData() const noexcept;
+
+    /** Provides mutable access to the CPU buffer. */
+    Span<uint8> mutablePixelData() noexcept;
+
+    /** Attempts to render the provided artboard into the offscreen buffer. */
+    bool render (rive::ArtboardInstance& artboard);
+
+    /** Returns true if the renderer owns a valid graphics context. */
+    bool isInitialised() const noexcept { return graphicsContext != nullptr; }
+
+private:
+    void allocateCpuBuffer();
+    bool ensureContext();
+
+    Options options;
+    uint32_t renderWidth = 0;
+    uint32_t renderHeight = 0;
+
+    std::unique_ptr<GraphicsContext> graphicsContext;
+    std::unique_ptr<rive::Renderer> riveRenderer;
+    std::vector<uint8> cpuBuffer;
+};
+
+} // namespace yup::rive_renderer

--- a/modules/yup_rive_renderer/renderer/yup_RiveRenderer.cpp
+++ b/modules/yup_rive_renderer/renderer/yup_RiveRenderer.cpp
@@ -1,0 +1,102 @@
+/*
+  ==============================================================================
+
+   This file is part of the YUP library.
+   Copyright (c) 2025 - kunitoki@gmail.com
+
+   YUP is an open source library subject to open-source licensing.
+
+   The code included in this file is provided under the terms of the ISC license
+   http://www.isc.org/downloads/software-support-policy/isc-license. Permission
+   to use, copy, modify, and/or distribute this software for any purpose with or
+   without fee is hereby granted provided that the above copyright notice and
+   this permission notice appear in all copies.
+
+   YUP IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
+   EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
+   DISCLAIMED.
+
+  ==============================================================================
+*/
+
+#include "yup_RiveRenderer.h"
+
+#include <algorithm>
+
+#include <yup_core/file/yup_File.h>
+#include <yup_core/memory/yup_MemoryBlock.h>
+
+namespace yup::rive_renderer
+{
+
+RiveRenderer::RiveRenderer (CreationOptions options)
+    : creationOptions (options)
+    , renderer (options.rendererOptions)
+{
+}
+
+bool RiveRenderer::load (const File& file)
+{
+    if (! ensureRendererIsConfigured())
+        return false;
+
+    if (! animationEngine.loadFromFile (file, *renderer.factory(), creationOptions.loadOptions))
+        return false;
+
+    if (creationOptions.rendererOptions.width == 0 || creationOptions.rendererOptions.height == 0)
+    {
+        const auto [artboardWidth, artboardHeight] = animationEngine.artboardDimensions();
+        const auto width = static_cast<uint32_t> (std::max (1.0f, artboardWidth));
+        const auto height = static_cast<uint32_t> (std::max (1.0f, artboardHeight));
+        renderer.resize (width, height);
+    }
+
+    return true;
+}
+
+bool RiveRenderer::loadFromData (Span<const uint8> data)
+{
+    if (! ensureRendererIsConfigured())
+        return false;
+
+    if (! animationEngine.loadFromData (data, *renderer.factory(), creationOptions.loadOptions))
+        return false;
+
+    if (creationOptions.rendererOptions.width == 0 || creationOptions.rendererOptions.height == 0)
+    {
+        const auto [artboardWidth, artboardHeight] = animationEngine.artboardDimensions();
+        renderer.resize (static_cast<uint32_t> (std::max (1.0f, artboardWidth)),
+                         static_cast<uint32_t> (std::max (1.0f, artboardHeight)));
+    }
+
+    return true;
+}
+
+bool RiveRenderer::advance (float deltaSeconds)
+{
+    const auto didAdvance = animationEngine.advance (deltaSeconds);
+
+    if (didAdvance)
+        renderFrame();
+
+    return didAdvance;
+}
+
+bool RiveRenderer::renderFrame()
+{
+    auto* artboard = animationEngine.artboard();
+    if (artboard == nullptr)
+        return false;
+
+    return renderer.render (*artboard);
+}
+
+bool RiveRenderer::ensureRendererIsConfigured()
+{
+    if (renderer.factory() != nullptr)
+        return true;
+
+    return renderer.isInitialised();
+}
+
+} // namespace yup::rive_renderer

--- a/modules/yup_rive_renderer/renderer/yup_RiveRenderer.h
+++ b/modules/yup_rive_renderer/renderer/yup_RiveRenderer.h
@@ -1,0 +1,86 @@
+/*
+  ==============================================================================
+
+   This file is part of the YUP library.
+   Copyright (c) 2025 - kunitoki@gmail.com
+
+   YUP is an open source library subject to open-source licensing.
+
+   The code included in this file is provided under the terms of the ISC license
+   http://www.isc.org/downloads/software-support-policy/isc-license. Permission
+   to use, copy, modify, and/or distribute this software for any purpose with or
+   without fee is hereby granted provided that the above copyright notice and
+   this permission notice appear in all copies.
+
+   YUP IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
+   EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
+   DISCLAIMED.
+
+  ==============================================================================
+*/
+
+#pragma once
+
+#include <optional>
+#include <vector>
+
+#include <yup_core/yup_core.h>
+
+#include "yup_RiveOffscreenRenderer.h"
+#include "../engine/yup_RiveAnimationEngine.h"
+
+namespace yup::rive_renderer
+{
+
+/** High level convenience wrapper combining the animation engine and the
+    offscreen renderer. */
+class YUP_API RiveRenderer
+{
+public:
+    struct CreationOptions
+    {
+        RiveOffscreenRenderer::Options rendererOptions;
+        RiveAnimationEngine::LoadOptions loadOptions;
+    };
+
+    explicit RiveRenderer (CreationOptions options = {});
+
+    bool load (const File& file);
+    bool loadFromData (Span<const uint8> data);
+
+    std::vector<std::string> animationNames() const { return animationEngine.animationNames(); }
+    std::vector<std::string> stateMachineNames() const { return animationEngine.stateMachineNames(); }
+
+    bool playAnimation (const std::string& name, bool loop = true) { return animationEngine.playAnimation (name, loop); }
+    bool playStateMachine (const std::string& name) { return animationEngine.playStateMachine (name); }
+
+    void stop() { animationEngine.stop(); }
+    void pause() { animationEngine.setPaused (true); }
+    void resume() { animationEngine.setPaused (false); }
+    bool paused() const noexcept { return animationEngine.paused(); }
+
+    bool setNumberInput (const std::string& name, float value) { return animationEngine.setNumberInput (name, value); }
+    bool setBooleanInput (const std::string& name, bool value) { return animationEngine.setBooleanInput (name, value); }
+    bool fireTrigger (const std::string& name) { return animationEngine.fireTrigger (name); }
+
+    bool advance (float deltaSeconds);
+
+    uint32_t width() const noexcept { return renderer.width(); }
+    uint32_t height() const noexcept { return renderer.height(); }
+
+    Span<const uint8> pixelData() const noexcept { return renderer.pixelData(); }
+
+    bool renderFrame();
+
+    const std::optional<std::string>& currentAnimation() const noexcept { return animationEngine.currentAnimation(); }
+    const std::optional<std::string>& currentStateMachine() const noexcept { return animationEngine.currentStateMachine(); }
+
+private:
+    bool ensureRendererIsConfigured();
+
+    CreationOptions creationOptions;
+    RiveOffscreenRenderer renderer;
+    RiveAnimationEngine animationEngine;
+};
+
+} // namespace yup::rive_renderer

--- a/modules/yup_rive_renderer/yup_rive_renderer.cpp
+++ b/modules/yup_rive_renderer/yup_rive_renderer.cpp
@@ -1,0 +1,30 @@
+/*
+  ==============================================================================
+
+   This file is part of the the YUP library.
+   Copyright (c) 2025 - kunitoki@gmail.com
+
+   YUP is an open source library subject to open-source licensing.
+
+   The code included in this file is provided under the terms of the ISC license
+   http://www.isc.org/downloads/software-support-policy/isc-license. Permission
+   to use, copy, modify, and/or distribute this software for any purpose with or
+   without fee is hereby granted provided that the above copyright notice and
+   this permission notice appear in all copies.
+
+   YUP IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
+   EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
+   DISCLAIMED.
+
+  ==============================================================================
+*/
+
+#ifdef YUP_RIVE_RENDERER_H_INCLUDED
+#error "Incorrect use of YUP cpp file"
+#endif
+
+#include "yup_rive_renderer.h"
+
+#include "engine/yup_RiveAnimationEngine.cpp"
+#include "renderer/yup_RiveOffscreenRenderer.cpp"
+#include "renderer/yup_RiveRenderer.cpp"

--- a/modules/yup_rive_renderer/yup_rive_renderer.h
+++ b/modules/yup_rive_renderer/yup_rive_renderer.h
@@ -1,0 +1,56 @@
+/*
+  ==============================================================================
+
+   This file is part of the YUP library.
+   Copyright (c) 2025 - kunitoki@gmail.com
+
+   YUP is an open source library subject to open-source licensing.
+
+   The code included in this file is provided under the terms of the ISC license
+   http://www.isc.org/downloads/software-support-policy/isc-license. Permission
+   to use, copy, modify, and/or distribute this software for any purpose with or
+   without fee is hereby granted provided that the above copyright notice and
+   this permission notice appear in all copies.
+
+   YUP IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
+   EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
+   DISCLAIMED.
+
+  ==============================================================================
+*/
+
+/*
+  ==============================================================================
+
+  BEGIN_YUP_MODULE_DECLARATION
+
+    ID:                 yup_rive_renderer
+    vendor:             yup
+    version:            0.1.0
+    name:               YUP Rive Renderer Helpers
+    description:        Helpers for driving Rive animations and preparing frames for streaming.
+    website:            https://github.com/kunitoki/yup
+    license:            ISC
+
+    dependencies:       yup_core yup_graphics
+    searchpaths:        native
+
+  END_YUP_MODULE_DECLARATION
+
+  ==============================================================================
+*/
+
+#pragma once
+#define YUP_RIVE_RENDERER_H_INCLUDED
+
+#include <yup_core/yup_core.h>
+#include <yup_graphics/yup_graphics.h>
+
+#include <rive/artboard.hpp>
+#include <rive/animation/linear_animation_instance.hpp>
+#include <rive/animation/state_machine_instance.hpp>
+#include <rive/file.hpp>
+
+#include "engine/yup_RiveAnimationEngine.h"
+#include "renderer/yup_RiveOffscreenRenderer.h"
+#include "renderer/yup_RiveRenderer.h"


### PR DESCRIPTION
## Summary
- introduce the new `yup_rive_renderer` module with animation, renderer, and offscreen management helpers
- expose a first round of pybind11 bindings so Python can drive the renderer lifecycle and retrieve frame buffers
- wire the module into the default CMake module list and Python package so it is available to downstream users

## Testing
- `cmake -S . -B build` *(fails: missing system package `alsa` in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d29c675f448329a3fc87408c467a58