### PR TITLE
Add synchronized frame access and byte loading for Rive renderer

### DIFF
--- a/modules/yup_gui/artboard/yup_RiveOffscreenRenderer.h
+++ b/modules/yup_gui/artboard/yup_RiveOffscreenRenderer.h
@@ -53,6 +53,9 @@ public:
     /** Loads a Rive file from disk. */
     Result load (const File& file, const String& artboardName = {});
 
+    /** Loads a Rive file from an in-memory buffer. */
+    Result loadFromBytes (Span<const uint8> bytes, const String& artboardName = {});
+
     /** Lists the available linear animations in the currently loaded artboard. */
     StringArray listAnimations() const;
 


### PR DESCRIPTION
## Summary
- protect Rive frame buffer updates with a mutex-backed snapshot to avoid torn reads
- add support for loading Rive artboards from in-memory byte buffers
- expose the new byte-loading capability to Python via a load_bytes helper

## Testing
- not run (not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68d2b1788ffc8329a7363a97e4cf979c