### PR TITLE
Make audio modules optional in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,7 @@ option (YUP_TARGET_ANDROID_BUILD_GRADLE "When building for Android, build the gr
 option (YUP_ENABLE_PROFILING "Enable the profiling code using Perfetto SDK" OFF)
 option (YUP_ENABLE_COVERAGE "Enable code coverage collection for tests" OFF)
 option (YUP_EXPORT_MODULES "Export the modules to the parent project" ON)
+option (YUP_ENABLE_AUDIO_MODULES "Build audio and DSP modules" ON)
 option (YUP_ENABLE_STATIC_PYTHON_LIBS "Use static Python libraries" OFF)
 option (YUP_BUILD_JAVA_SUPPORT "Build the Java support" OFF)
 option (YUP_BUILD_EXAMPLES "Build the examples" ${PROJECT_IS_TOP_LEVEL})
@@ -58,7 +59,9 @@ if (YUP_EXPORT_MODULES)
         set (enable_python OFF)
     endif()
 
-    yup_add_default_modules (${CMAKE_CURRENT_LIST_DIR} ENABLE_PYTHON ${enable_python})
+    yup_add_default_modules (${CMAKE_CURRENT_LIST_DIR}
+        ENABLE_PYTHON ${enable_python}
+        ENABLE_AUDIO ${YUP_ENABLE_AUDIO_MODULES})
 endif()
 
 # Enable profiling
@@ -73,7 +76,7 @@ if (YUP_BUILD_EXAMPLES)
     add_subdirectory (examples/console)
     add_subdirectory (examples/app)
     add_subdirectory (examples/graphics)
-    if (YUP_PLATFORM_DESKTOP)
+    if (YUP_PLATFORM_DESKTOP AND YUP_ENABLE_AUDIO_MODULES)
         add_subdirectory (examples/plugin)
     endif()
 endif()

--- a/cmake/yup_audio_plugin.cmake
+++ b/cmake/yup_audio_plugin.cmake
@@ -38,6 +38,10 @@ function (yup_audio_plugin)
 
     _yup_set_default (YUP_ARG_TARGET_CXX_STANDARD 17)
 
+    if (DEFINED YUP_ENABLE_AUDIO_MODULES AND NOT YUP_ENABLE_AUDIO_MODULES)
+        _yup_message (FATAL_ERROR "Audio plugin targets require YUP_ENABLE_AUDIO_MODULES to be ON.")
+    endif()
+
     set (target_name "${YUP_ARG_TARGET_NAME}")
     set (target_version "${YUP_ARG_TARGET_VERSION}")
     set (target_ide_group "${YUP_ARG_TARGET_IDE_GROUP}")

--- a/examples/app/CMakeLists.txt
+++ b/examples/app/CMakeLists.txt
@@ -25,6 +25,10 @@ set (target_version "1.0.0")
 
 project (${target_name} VERSION ${target_version})
 
+if (NOT DEFINED YUP_ENABLE_AUDIO_MODULES)
+    set (YUP_ENABLE_AUDIO_MODULES ON)
+endif()
+
 # ==== Prepare Android build
 if (ANDROID)
     include (../../cmake/yup.cmake)
@@ -32,6 +36,19 @@ if (ANDROID)
 endif()
 
 # ==== Prepare target
+set (example_modules
+    yup::yup_core
+    yup::yup_events
+    yup::yup_graphics
+    yup::yup_gui)
+
+if (YUP_ENABLE_AUDIO_MODULES)
+    list (INSERT example_modules 1
+        yup::yup_audio_basics
+        yup::yup_audio_devices
+        yup::yup_audio_processors)
+endif()
+
 yup_standalone_app (
     TARGET_NAME ${target_name}
     TARGET_VERSION ${target_version}
@@ -39,13 +56,7 @@ yup_standalone_app (
     TARGET_APP_ID "org.yup.${target_name}"
     TARGET_APP_NAMESPACE "org.yup"
     MODULES
-        yup::yup_core
-        yup::yup_audio_basics
-        yup::yup_audio_devices
-        yup::yup_events
-        yup::yup_graphics
-        yup::yup_gui
-        yup::yup_audio_processors)
+        ${example_modules})
 
 # ==== Prepare sources
 if (NOT YUP_TARGET_ANDROID)

--- a/examples/console/CMakeLists.txt
+++ b/examples/console/CMakeLists.txt
@@ -25,6 +25,10 @@ set (target_version "1.0.0")
 
 project (${target_name} VERSION ${target_version})
 
+if (NOT DEFINED YUP_ENABLE_AUDIO_MODULES)
+    set (YUP_ENABLE_AUDIO_MODULES ON)
+endif()
+
 # ==== Prepare Android build
 if (ANDROID)
     include (../../cmake/yup.cmake)
@@ -32,6 +36,16 @@ if (ANDROID)
 endif()
 
 # ==== Prepare target
+set (example_modules
+    yup::yup_core
+    yup::yup_events)
+
+if (YUP_ENABLE_AUDIO_MODULES)
+    list (INSERT example_modules 1
+        yup::yup_audio_basics
+        yup::yup_audio_devices)
+endif()
+
 yup_standalone_app (
     TARGET_NAME ${target_name}
     TARGET_VERSION ${target_version}
@@ -40,10 +54,7 @@ yup_standalone_app (
     TARGET_APP_NAMESPACE "org.yup"
     TARGET_CONSOLE ON
     MODULES
-        yup::yup_core
-        yup::yup_audio_basics
-        yup::yup_audio_devices
-        yup::yup_events)
+        ${example_modules})
 
 # ==== Prepare sources
 if (NOT YUP_TARGET_ANDROID)

--- a/examples/graphics/CMakeLists.txt
+++ b/examples/graphics/CMakeLists.txt
@@ -27,8 +27,12 @@ project (${target_name} VERSION ${target_version})
 
 set (rive_file "data/alien.riv")
 
+if (NOT DEFINED YUP_ENABLE_AUDIO_MODULES)
+    set (YUP_ENABLE_AUDIO_MODULES ON)
+endif()
+
 # ==== Prepare Android build
-set (link_libraries "")
+set (link_libraries)
 if (ANDROID)
     include (../../cmake/yup.cmake)
     yup_add_default_modules ("${CMAKE_CURRENT_LIST_DIR}/../..")
@@ -52,6 +56,28 @@ if (YUP_PLATFORM_DESKTOP)
     set (additional_modules yup::yup_python)
 endif()
 
+set (example_modules
+    yup::yup_core
+    yup::yup_events
+    yup::yup_graphics
+    yup::yup_gui
+    libpng
+    libwebp
+    ${additional_modules}
+    ${link_libraries})
+
+if (YUP_ENABLE_AUDIO_MODULES)
+    list (INSERT example_modules 1
+        yup::yup_audio_basics
+        yup::yup_audio_devices
+        yup::yup_dsp
+        yup::yup_audio_gui
+        yup::yup_audio_processors
+        yup::yup_audio_formats
+        pffft_library
+        dr_libs)
+endif()
+
 yup_standalone_app (
     TARGET_NAME ${target_name}
     TARGET_VERSION ${target_version}
@@ -63,22 +89,7 @@ yup_standalone_app (
     PRELOAD_FILES
         "${CMAKE_CURRENT_LIST_DIR}/${rive_file}@${rive_file}"
     MODULES
-        yup::yup_core
-        yup::yup_audio_basics
-        yup::yup_audio_devices
-        yup::yup_dsp
-        yup::yup_events
-        yup::yup_graphics
-        yup::yup_gui
-        yup::yup_audio_gui
-        yup::yup_audio_processors
-        yup::yup_audio_formats
-        pffft_library
-        dr_libs
-        libpng
-        libwebp
-        ${additional_modules}
-        ${link_libraries})
+        ${example_modules})
 
 # ==== Prepare sources
 if (NOT YUP_TARGET_ANDROID)

--- a/examples/plugin/CMakeLists.txt
+++ b/examples/plugin/CMakeLists.txt
@@ -25,6 +25,15 @@ set (target_version "1.0.0")
 
 project (${target_name} VERSION ${target_version})
 
+if (NOT DEFINED YUP_ENABLE_AUDIO_MODULES)
+    set (YUP_ENABLE_AUDIO_MODULES ON)
+endif()
+
+if (NOT YUP_ENABLE_AUDIO_MODULES)
+    message (STATUS "YUP -- Skipping plugin example because audio modules are disabled")
+    return()
+endif()
+
 yup_audio_plugin (
     TARGET_NAME ${target_name}
     TARGET_VERSION ${target_version}

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -22,12 +22,32 @@ cmake_minimum_required (VERSION 3.28)
 _yup_get_project_version_string (${CMAKE_CURRENT_LIST_DIR}/../modules yup_version)
 _yup_message (STATUS "Building project version ${yup_version}")
 
+if (NOT DEFINED YUP_ENABLE_AUDIO_MODULES)
+    set (YUP_ENABLE_AUDIO_MODULES ON)
+endif()
+
 set (target_name yup)
 set (target_version ${yup_version})
 project (${target_name} VERSION ${target_version})
 
+set (python_modules
+    yup::yup_core
+    yup::yup_data_model
+    yup::yup_events
+    yup::yup_graphics
+    yup::yup_gui
+    yup::yup_python)
+
+if (YUP_ENABLE_AUDIO_MODULES)
+    list (PREPEND python_modules
+        yup::yup_audio_basics
+        yup::yup_audio_devices
+        yup::yup_audio_processors)
+endif()
+
 yup_add_default_modules ("${CMAKE_CURRENT_LIST_DIR}/.."
     ENABLE_PYTHON ON
+    ENABLE_AUDIO ${YUP_ENABLE_AUDIO_MODULES}
     DEFINITIONS
         YUP_STANDALONE_APPLICATION=1
         YUP_DISABLE_JUCE_VERSION_PRINTING=1
@@ -50,15 +70,7 @@ yup_standalone_app (
     TARGET_APP_NAMESPACE "org.yup"
     TARGET_WHEEL ON
     MODULES
-        yup::yup_audio_basics
-        yup::yup_audio_devices
-        yup::yup_audio_processors
-        yup::yup_core
-        yup::yup_data_model
-        yup::yup_events
-        yup::yup_graphics
-        yup::yup_gui
-        yup::yup_python)
+        ${python_modules})
 
 set_target_properties (${target_name} PROPERTIES
     CXX_EXTENSIONS OFF

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -21,6 +21,10 @@ cmake_minimum_required(VERSION 3.28)
 
 enable_testing()
 
+if (NOT DEFINED YUP_ENABLE_AUDIO_MODULES)
+    set (YUP_ENABLE_AUDIO_MODULES ON)
+endif()
+
 # ==== Setup googletests
 if (YUP_PLATFORM_EMSCRIPTEN)
     set (gtest_disable_pthreads ON CACHE BOOL "" FORCE)
@@ -54,17 +58,24 @@ set (target_console OFF)
 set (target_gtest_modules "")
 set (target_modules
     yup_core
-    yup_audio_basics
-    yup_audio_devices
-    yup_audio_formats
-    yup_dsp
     yup_events
     yup_data_model
-    yup_graphics
-    pffft_library)
+    yup_graphics)
+
+if (YUP_ENABLE_AUDIO_MODULES)
+    list (APPEND target_modules
+        yup_audio_basics
+        yup_audio_devices
+        yup_audio_formats
+        yup_dsp
+        pffft_library)
+endif()
 
 if (NOT YUP_PLATFORM_EMSCRIPTEN)
-    list (APPEND target_modules yup_gui yup_audio_gui)
+    list (APPEND target_modules yup_gui)
+    if (YUP_ENABLE_AUDIO_MODULES)
+        list (APPEND target_modules yup_audio_gui)
+    endif()
     if (YUP_PLATFORM_DESKTOP AND NOT YUP_PLATFORM_WINDOWS)
         list (APPEND target_modules yup_python)
     endif()


### PR DESCRIPTION
## Summary
- add a YUP_ENABLE_AUDIO_MODULES option and forward it into default module registration
- update yup_add_default_modules to skip audio third-party and module targets when audio support is disabled
- guard python/tests/examples/plugin module lists so audio targets are referenced only when they exist

## Testing
- cmake -S . -B build -DYUP_ENABLE_AUDIO_MODULES=OFF -DYUP_BUILD_EXAMPLES=OFF -DYUP_BUILD_TESTS=OFF -DYUP_BUILD_WHEEL=OFF

------
https://chatgpt.com/codex/tasks/task_e_68d2bc173a3083299013443f44536d82