### PR TITLE
Stabilize audio toggle definition

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,7 +58,7 @@ if (YUP_EXPORT_MODULES)
         set (enable_python OFF)
     endif()
 
-    yup_add_default_modules (${CMAKE_CURRENT_LIST_DIR} ENABLE_PYTHON ${enable_python})
+    yup_add_default_modules (${CMAKE_CURRENT_LIST_DIR} ENABLE_PYTHON ${enable_python} ENABLE_AUDIO ${YUP_ENABLE_AUDIO_MODULES})
 endif()
 
 # Enable profiling

--- a/cmake/yup_audio_plugin.cmake
+++ b/cmake/yup_audio_plugin.cmake
@@ -38,6 +38,10 @@ function (yup_audio_plugin)
 
     _yup_set_default (YUP_ARG_TARGET_CXX_STANDARD 17)
 
+    if (DEFINED YUP_ENABLE_AUDIO_MODULES AND NOT YUP_ENABLE_AUDIO_MODULES)
+        _yup_message (FATAL_ERROR "Audio plugin targets require YUP_ENABLE_AUDIO_MODULES to be ON.")
+    endif()
+
     set (target_name "${YUP_ARG_TARGET_NAME}")
     set (target_version "${YUP_ARG_TARGET_VERSION}")
     set (target_ide_group "${YUP_ARG_TARGET_IDE_GROUP}")

--- a/cmake/yup_modules.cmake
+++ b/cmake/yup_modules.cmake
@@ -19,6 +19,15 @@
 
 #==============================================================================
 
+if (NOT DEFINED YUP_ENABLE_AUDIO_MODULES)
+    set (_yup_enable_audio_default ON)
+else()
+    set (_yup_enable_audio_default ${YUP_ENABLE_AUDIO_MODULES})
+endif()
+
+set (YUP_ENABLE_AUDIO_MODULES ${_yup_enable_audio_default} CACHE BOOL "Build audio and DSP modules")
+unset (_yup_enable_audio_default)
+
 function (_yup_module_parse_config module_header output_module_configs output_module_user_configs)
     set (module_configs "")
     set (module_user_configs "")
@@ -599,11 +608,12 @@ macro (yup_add_default_modules modules_path)
 
     # ==== Fetch options
     set (options "")
-    set (one_value_args ENABLE_PYTHON)
+    set (one_value_args ENABLE_PYTHON ENABLE_AUDIO)
     set (multi_value_args DEFINITIONS)
     cmake_parse_arguments (YUP_ARG "${options}" "${one_value_args}" "${multi_value_args}" ${ARGN})
     _yup_set_default (YUP_ARG_TARGET_DEFINITIONS "")
     _yup_set_default (YUP_ARG_ENABLE_PYTHON OFF)
+    _yup_set_default (YUP_ARG_ENABLE_AUDIO ${YUP_ENABLE_AUDIO_MODULES})
     set (modules_definitions "${YUP_ARG_DEFINITIONS}")
 
     # ==== Thirdparty modules
@@ -618,9 +628,11 @@ macro (yup_add_default_modules modules_path)
     yup_add_module (${modules_path}/thirdparty/rive "${modules_definitions}" ${thirdparty_group})
     yup_add_module (${modules_path}/thirdparty/rive_decoders "${modules_definitions}" ${thirdparty_group})
     yup_add_module (${modules_path}/thirdparty/rive_renderer "${modules_definitions}" ${thirdparty_group})
-    yup_add_module (${modules_path}/thirdparty/oboe_library "${modules_definitions}" ${thirdparty_group})
-    yup_add_module (${modules_path}/thirdparty/pffft_library "${modules_definitions}" ${thirdparty_group})
-    yup_add_module (${modules_path}/thirdparty/dr_libs "${modules_definitions}" ${thirdparty_group})
+    if (YUP_ARG_ENABLE_AUDIO)
+        yup_add_module (${modules_path}/thirdparty/oboe_library "${modules_definitions}" ${thirdparty_group})
+        yup_add_module (${modules_path}/thirdparty/pffft_library "${modules_definitions}" ${thirdparty_group})
+        yup_add_module (${modules_path}/thirdparty/dr_libs "${modules_definitions}" ${thirdparty_group})
+    endif()
 
     # ==== Yup modules
     set (modules_group "Modules")
@@ -633,8 +645,10 @@ macro (yup_add_default_modules modules_path)
     yup_add_module (${modules_path}/modules/yup_data_model "${modules_definitions}" ${modules_group})
     add_library (yup::yup_data_model ALIAS yup_data_model)
 
-    yup_add_module (${modules_path}/modules/yup_dsp "${modules_definitions}" ${modules_group})
-    add_library (yup::yup_dsp ALIAS yup_dsp)
+    if (YUP_ARG_ENABLE_AUDIO)
+        yup_add_module (${modules_path}/modules/yup_dsp "${modules_definitions}" ${modules_group})
+        add_library (yup::yup_dsp ALIAS yup_dsp)
+    endif()
 
     yup_add_module (${modules_path}/modules/yup_graphics "${modules_definitions}" ${modules_group})
     add_library (yup::yup_graphics ALIAS yup_graphics)
@@ -642,23 +656,19 @@ macro (yup_add_default_modules modules_path)
     yup_add_module (${modules_path}/modules/yup_gui "${modules_definitions}" ${modules_group})
     add_library (yup::yup_gui ALIAS yup_gui)
 
-    yup_add_module (${modules_path}/modules/yup_audio_basics "${modules_definitions}" ${modules_group})
-    add_library (yup::yup_audio_basics ALIAS yup_audio_basics)
-
-    yup_add_module (${modules_path}/modules/yup_audio_devices "${modules_definitions}" ${modules_group})
-    add_library (yup::yup_audio_devices ALIAS yup_audio_devices)
-
-    yup_add_module (${modules_path}/modules/yup_audio_formats "${modules_definitions}" ${modules_group})
-    add_library (yup::yup_audio_formats ALIAS yup_audio_formats)
-
-    yup_add_module (${modules_path}/modules/yup_audio_processors "${modules_definitions}" ${modules_group})
-    add_library (yup::yup_audio_processors ALIAS yup_audio_processors)
-
-    yup_add_module (${modules_path}/modules/yup_audio_gui "${modules_definitions}" ${modules_group})
-    add_library (yup::yup_audio_gui ALIAS yup_audio_gui)
-
-    yup_add_module (${modules_path}/modules/yup_audio_plugin_client "${modules_definitions}" ${modules_group})
-    add_library (yup::yup_audio_plugin_client ALIAS yup_audio_plugin_client)
+    if (YUP_ARG_ENABLE_AUDIO)
+        set (audio_modules
+            yup_audio_basics
+            yup_audio_devices
+            yup_audio_formats
+            yup_audio_processors
+            yup_audio_gui
+            yup_audio_plugin_client)
+        foreach (audio_module IN LISTS audio_modules)
+            yup_add_module (${modules_path}/modules/${audio_module} "${modules_definitions}" ${modules_group})
+            add_library (yup::${audio_module} ALIAS ${audio_module})
+        endforeach()
+    endif()
 
     if (YUP_ARG_ENABLE_PYTHON)
         if (NOT YUP_BUILD_WHEEL)

--- a/examples/app/CMakeLists.txt
+++ b/examples/app/CMakeLists.txt
@@ -25,13 +25,31 @@ set (target_version "1.0.0")
 
 project (${target_name} VERSION ${target_version})
 
+if (NOT DEFINED YUP_ENABLE_AUDIO_MODULES)
+    set (YUP_ENABLE_AUDIO_MODULES ON)
+endif()
+
 # ==== Prepare Android build
 if (ANDROID)
     include (../../cmake/yup.cmake)
-    yup_add_default_modules ("${CMAKE_CURRENT_LIST_DIR}/../..")
+    yup_add_default_modules ("${CMAKE_CURRENT_LIST_DIR}/../.."
+        ENABLE_AUDIO ${YUP_ENABLE_AUDIO_MODULES})
 endif()
 
 # ==== Prepare target
+set (example_modules
+    yup::yup_core
+    yup::yup_events
+    yup::yup_graphics
+    yup::yup_gui)
+
+if (YUP_ENABLE_AUDIO_MODULES)
+    list (INSERT example_modules 1
+        yup::yup_audio_basics
+        yup::yup_audio_devices
+        yup::yup_audio_processors)
+endif()
+
 yup_standalone_app (
     TARGET_NAME ${target_name}
     TARGET_VERSION ${target_version}
@@ -39,13 +57,7 @@ yup_standalone_app (
     TARGET_APP_ID "org.yup.${target_name}"
     TARGET_APP_NAMESPACE "org.yup"
     MODULES
-        yup::yup_core
-        yup::yup_audio_basics
-        yup::yup_audio_devices
-        yup::yup_events
-        yup::yup_graphics
-        yup::yup_gui
-        yup::yup_audio_processors)
+        ${example_modules})
 
 # ==== Prepare sources
 if (NOT YUP_TARGET_ANDROID)

--- a/examples/console/CMakeLists.txt
+++ b/examples/console/CMakeLists.txt
@@ -25,13 +25,28 @@ set (target_version "1.0.0")
 
 project (${target_name} VERSION ${target_version})
 
+if (NOT DEFINED YUP_ENABLE_AUDIO_MODULES)
+    set (YUP_ENABLE_AUDIO_MODULES ON)
+endif()
+
 # ==== Prepare Android build
 if (ANDROID)
     include (../../cmake/yup.cmake)
-    yup_add_default_modules ("${CMAKE_CURRENT_LIST_DIR}/../..")
+    yup_add_default_modules ("${CMAKE_CURRENT_LIST_DIR}/../.."
+        ENABLE_AUDIO ${YUP_ENABLE_AUDIO_MODULES})
 endif()
 
 # ==== Prepare target
+set (example_modules
+    yup::yup_core
+    yup::yup_events)
+
+if (YUP_ENABLE_AUDIO_MODULES)
+    list (INSERT example_modules 1
+        yup::yup_audio_basics
+        yup::yup_audio_devices)
+endif()
+
 yup_standalone_app (
     TARGET_NAME ${target_name}
     TARGET_VERSION ${target_version}
@@ -40,10 +55,7 @@ yup_standalone_app (
     TARGET_APP_NAMESPACE "org.yup"
     TARGET_CONSOLE ON
     MODULES
-        yup::yup_core
-        yup::yup_audio_basics
-        yup::yup_audio_devices
-        yup::yup_events)
+        ${example_modules})
 
 # ==== Prepare sources
 if (NOT YUP_TARGET_ANDROID)

--- a/examples/graphics/CMakeLists.txt
+++ b/examples/graphics/CMakeLists.txt
@@ -27,11 +27,16 @@ project (${target_name} VERSION ${target_version})
 
 set (rive_file "data/alien.riv")
 
+if (NOT DEFINED YUP_ENABLE_AUDIO_MODULES)
+    set (YUP_ENABLE_AUDIO_MODULES ON)
+endif()
+
 # ==== Prepare Android build
-set (link_libraries "")
+set (link_libraries)
 if (ANDROID)
     include (../../cmake/yup.cmake)
-    yup_add_default_modules ("${CMAKE_CURRENT_LIST_DIR}/../..")
+    yup_add_default_modules ("${CMAKE_CURRENT_LIST_DIR}/../.."
+        ENABLE_AUDIO ${YUP_ENABLE_AUDIO_MODULES})
 
     yup_add_embedded_binary_resources (
         "${target_name}_binary_data"
@@ -52,6 +57,28 @@ if (YUP_PLATFORM_DESKTOP)
     set (additional_modules yup::yup_python)
 endif()
 
+set (example_modules
+    yup::yup_core
+    yup::yup_events
+    yup::yup_graphics
+    yup::yup_gui
+    libpng
+    libwebp
+    ${additional_modules}
+    ${link_libraries})
+
+if (YUP_ENABLE_AUDIO_MODULES)
+    list (INSERT example_modules 1
+        yup::yup_audio_basics
+        yup::yup_audio_devices
+        yup::yup_dsp
+        yup::yup_audio_gui
+        yup::yup_audio_processors
+        yup::yup_audio_formats
+        pffft_library
+        dr_libs)
+endif()
+
 yup_standalone_app (
     TARGET_NAME ${target_name}
     TARGET_VERSION ${target_version}
@@ -63,22 +90,7 @@ yup_standalone_app (
     PRELOAD_FILES
         "${CMAKE_CURRENT_LIST_DIR}/${rive_file}@${rive_file}"
     MODULES
-        yup::yup_core
-        yup::yup_audio_basics
-        yup::yup_audio_devices
-        yup::yup_dsp
-        yup::yup_events
-        yup::yup_graphics
-        yup::yup_gui
-        yup::yup_audio_gui
-        yup::yup_audio_processors
-        yup::yup_audio_formats
-        pffft_library
-        dr_libs
-        libpng
-        libwebp
-        ${additional_modules}
-        ${link_libraries})
+        ${example_modules})
 
 # ==== Prepare sources
 if (NOT YUP_TARGET_ANDROID)

--- a/examples/plugin/CMakeLists.txt
+++ b/examples/plugin/CMakeLists.txt
@@ -25,6 +25,15 @@ set (target_version "1.0.0")
 
 project (${target_name} VERSION ${target_version})
 
+if (NOT DEFINED YUP_ENABLE_AUDIO_MODULES)
+    set (YUP_ENABLE_AUDIO_MODULES ON)
+endif()
+
+if (NOT YUP_ENABLE_AUDIO_MODULES)
+    message (STATUS "YUP -- Skipping plugin example because audio modules are disabled")
+    return()
+endif()
+
 yup_audio_plugin (
     TARGET_NAME ${target_name}
     TARGET_VERSION ${target_version}

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -22,12 +22,32 @@ cmake_minimum_required (VERSION 3.28)
 _yup_get_project_version_string (${CMAKE_CURRENT_LIST_DIR}/../modules yup_version)
 _yup_message (STATUS "Building project version ${yup_version}")
 
+if (NOT DEFINED YUP_ENABLE_AUDIO_MODULES)
+    set (YUP_ENABLE_AUDIO_MODULES ON)
+endif()
+
 set (target_name yup)
 set (target_version ${yup_version})
 project (${target_name} VERSION ${target_version})
 
+set (python_modules
+    yup::yup_core
+    yup::yup_data_model
+    yup::yup_events
+    yup::yup_graphics
+    yup::yup_gui
+    yup::yup_python)
+
+if (YUP_ENABLE_AUDIO_MODULES)
+    list (PREPEND python_modules
+        yup::yup_audio_basics
+        yup::yup_audio_devices
+        yup::yup_audio_processors)
+endif()
+
 yup_add_default_modules ("${CMAKE_CURRENT_LIST_DIR}/.."
     ENABLE_PYTHON ON
+    ENABLE_AUDIO ${YUP_ENABLE_AUDIO_MODULES}
     DEFINITIONS
         YUP_STANDALONE_APPLICATION=1
         YUP_DISABLE_JUCE_VERSION_PRINTING=1
@@ -50,15 +70,7 @@ yup_standalone_app (
     TARGET_APP_NAMESPACE "org.yup"
     TARGET_WHEEL ON
     MODULES
-        yup::yup_audio_basics
-        yup::yup_audio_devices
-        yup::yup_audio_processors
-        yup::yup_core
-        yup::yup_data_model
-        yup::yup_events
-        yup::yup_graphics
-        yup::yup_gui
-        yup::yup_python)
+        ${python_modules})
 
 set_target_properties (${target_name} PROPERTIES
     CXX_EXTENSIONS OFF

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -21,6 +21,10 @@ cmake_minimum_required(VERSION 3.28)
 
 enable_testing()
 
+if (NOT DEFINED YUP_ENABLE_AUDIO_MODULES)
+    set (YUP_ENABLE_AUDIO_MODULES ON)
+endif()
+
 # ==== Setup googletests
 if (YUP_PLATFORM_EMSCRIPTEN)
     set (gtest_disable_pthreads ON CACHE BOOL "" FORCE)
@@ -54,17 +58,24 @@ set (target_console OFF)
 set (target_gtest_modules "")
 set (target_modules
     yup_core
-    yup_audio_basics
-    yup_audio_devices
-    yup_audio_formats
-    yup_dsp
     yup_events
     yup_data_model
-    yup_graphics
-    pffft_library)
+    yup_graphics)
+
+if (YUP_ENABLE_AUDIO_MODULES)
+    list (APPEND target_modules
+        yup_audio_basics
+        yup_audio_devices
+        yup_audio_formats
+        yup_dsp
+        pffft_library)
+endif()
 
 if (NOT YUP_PLATFORM_EMSCRIPTEN)
-    list (APPEND target_modules yup_gui yup_audio_gui)
+    list (APPEND target_modules yup_gui)
+    if (YUP_ENABLE_AUDIO_MODULES)
+        list (APPEND target_modules yup_audio_gui)
+    endif()
     if (YUP_PLATFORM_DESKTOP AND NOT YUP_PLATFORM_WINDOWS)
         list (APPEND target_modules yup_python)
     endif()


### PR DESCRIPTION
## Summary
- register YUP_ENABLE_AUDIO_MODULES as a cache option inside yup_modules.cmake so the flag can be shared without redefining it in parent CMakeLists files
- keep the root CMakeLists free of option redefinition while still forwarding the audio flag when registering default modules

## Testing
- cmake -S . -B build -DYUP_ENABLE_AUDIO_MODULES=OFF -DYUP_BUILD_EXAMPLES=OFF -DYUP_BUILD_TESTS=OFF -DYUP_BUILD_WHEEL=OFF

------
https://chatgpt.com/codex/tasks/task_e_68d2bc173a3083299013443f44536d82