### PR TITLE
Add audio module toggle for Windows Rive NDI workflow

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,7 @@ option (YUP_BUILD_JAVA_SUPPORT "Build the Java support" OFF)
 option (YUP_BUILD_EXAMPLES "Build the examples" ${PROJECT_IS_TOP_LEVEL})
 option (YUP_BUILD_TESTS "Build the tests" ${PROJECT_IS_TOP_LEVEL})
 option (YUP_BUILD_WHEEL "Build the wheel" OFF)
+option (YUP_ENABLE_AUDIO_MODULES "Enable audio-related modules" ON)
 
 # Dependencies modules
 if (YUP_EXPORT_MODULES)

--- a/README.md
+++ b/README.md
@@ -158,8 +158,17 @@ Available recipes:
     ios_simulator PLATFORM="SIMULATORARM64" # generate and open project for iOS Simulator macOS using Xcode
     linux PROFILING="OFF"                   # generate project in Linux using Ninja
     mac PROFILING="OFF"                     # generate and open project in macOS using Xcode
+    rive_ndi_win CONFIG="Release"           # configure and build Windows Rive NDI pipeline wheel (audio disabled)
     win PROFILING="OFF"                     # generate and open project in Windows using Visual Studio
 ```
+
+To bootstrap the Windows-focused Rive + NDI pipeline (with audio modules disabled and the Python wheel enabled), run:
+
+```bash
+just rive_ndi_win
+```
+
+By default this configures a Visual Studio 2022 solution under `build/rive_ndi`, disables the audio modules via `-DYUP_ENABLE_AUDIO_MODULES=OFF`, enables wheel generation with `-DYUP_BUILD_WHEEL=ON`, and immediately builds the `yup` target. If you need a different configuration, override the `CONFIG` parameter (for example, `just rive_ndi_win CONFIG=Debug`). Once the build completes you can open the generated solution or iterate with additional `cmake --build build/rive_ndi --target yup --config Release` (or the matching configuration) invocations as needed.
 
 ## Preparing the build directory
 Create a Dedicated Build Directory:
@@ -180,6 +189,15 @@ For a standard desktop build with tests and examples enabled, run:
 cmake . -B build -DYUP_ENABLE_TESTS=ON -DYUP_ENABLE_EXAMPLES=ON
 cmake --build build --config Release --parallel 4
 ```
+
+### Windows Rive NDI workflow
+When focusing on the Direct3D-based Rive renderer feeding the Python NDI bindings, prefer the dedicated `just rive_ndi_win` recipe documented above. It configures with `YUP_BUILD_WHEEL=ON` and `YUP_ENABLE_AUDIO_MODULES=OFF`, so the resulting solution skips audio dependencies while keeping the renderer + wheel target ready. After the initial configure/build, subsequent edits can be recompiled with:
+
+```bash
+cmake --build build/rive_ndi --target yup --config Release
+```
+
+If you later require the audio toolchain, rerun configuration with `-DYUP_ENABLE_AUDIO_MODULES=ON` (or simply omit the override) to restore the default module set.
 
 
 ### Android

--- a/cmake/yup_modules.cmake
+++ b/cmake/yup_modules.cmake
@@ -633,32 +633,36 @@ macro (yup_add_default_modules modules_path)
     yup_add_module (${modules_path}/modules/yup_data_model "${modules_definitions}" ${modules_group})
     add_library (yup::yup_data_model ALIAS yup_data_model)
 
-    yup_add_module (${modules_path}/modules/yup_dsp "${modules_definitions}" ${modules_group})
-    add_library (yup::yup_dsp ALIAS yup_dsp)
-
     yup_add_module (${modules_path}/modules/yup_graphics "${modules_definitions}" ${modules_group})
     add_library (yup::yup_graphics ALIAS yup_graphics)
 
     yup_add_module (${modules_path}/modules/yup_gui "${modules_definitions}" ${modules_group})
     add_library (yup::yup_gui ALIAS yup_gui)
 
-    yup_add_module (${modules_path}/modules/yup_audio_basics "${modules_definitions}" ${modules_group})
-    add_library (yup::yup_audio_basics ALIAS yup_audio_basics)
+    if (YUP_ENABLE_AUDIO_MODULES)
+        yup_add_module (${modules_path}/modules/yup_dsp "${modules_definitions}" ${modules_group})
+        add_library (yup::yup_dsp ALIAS yup_dsp)
 
-    yup_add_module (${modules_path}/modules/yup_audio_devices "${modules_definitions}" ${modules_group})
-    add_library (yup::yup_audio_devices ALIAS yup_audio_devices)
+        yup_add_module (${modules_path}/modules/yup_audio_basics "${modules_definitions}" ${modules_group})
+        add_library (yup::yup_audio_basics ALIAS yup_audio_basics)
 
-    yup_add_module (${modules_path}/modules/yup_audio_formats "${modules_definitions}" ${modules_group})
-    add_library (yup::yup_audio_formats ALIAS yup_audio_formats)
+        yup_add_module (${modules_path}/modules/yup_audio_devices "${modules_definitions}" ${modules_group})
+        add_library (yup::yup_audio_devices ALIAS yup_audio_devices)
 
-    yup_add_module (${modules_path}/modules/yup_audio_processors "${modules_definitions}" ${modules_group})
-    add_library (yup::yup_audio_processors ALIAS yup_audio_processors)
+        yup_add_module (${modules_path}/modules/yup_audio_formats "${modules_definitions}" ${modules_group})
+        add_library (yup::yup_audio_formats ALIAS yup_audio_formats)
 
-    yup_add_module (${modules_path}/modules/yup_audio_gui "${modules_definitions}" ${modules_group})
-    add_library (yup::yup_audio_gui ALIAS yup_audio_gui)
+        yup_add_module (${modules_path}/modules/yup_audio_processors "${modules_definitions}" ${modules_group})
+        add_library (yup::yup_audio_processors ALIAS yup_audio_processors)
 
-    yup_add_module (${modules_path}/modules/yup_audio_plugin_client "${modules_definitions}" ${modules_group})
-    add_library (yup::yup_audio_plugin_client ALIAS yup_audio_plugin_client)
+        yup_add_module (${modules_path}/modules/yup_audio_gui "${modules_definitions}" ${modules_group})
+        add_library (yup::yup_audio_gui ALIAS yup_audio_gui)
+
+        yup_add_module (${modules_path}/modules/yup_audio_plugin_client "${modules_definitions}" ${modules_group})
+        add_library (yup::yup_audio_plugin_client ALIAS yup_audio_plugin_client)
+    else()
+        _yup_message (STATUS "Skipping audio modules (YUP_ENABLE_AUDIO_MODULES=OFF)")
+    endif()
 
     if (YUP_ARG_ENABLE_PYTHON)
         if (NOT YUP_BUILD_WHEEL)

--- a/docs/rive_ndi_overview.md
+++ b/docs/rive_ndi_overview.md
@@ -1,0 +1,25 @@
+# Windows Rive + NDI build overview
+
+The `rive_ndi_win` recipe in the root `justfile` streamlines configuring and compiling the Visual Studio 2022 solution that powers the Direct3D 11 Rive renderer and the Python wheel used for NDI streaming.
+
+## Configure and build in one step
+
+```bash
+just rive_ndi_win
+```
+
+This command performs two actions:
+
+1. Runs `cmake -G "Visual Studio 17 2022" -B build/rive_ndi -DYUP_ENABLE_AUDIO_MODULES=OFF -DYUP_BUILD_WHEEL=ON` to generate a dedicated build tree with audio modules disabled and the Python wheel enabled.
+2. Invokes `cmake --build build/rive_ndi --target yup --config Release` so the renderer + bindings are ready without opening Visual Studio manually.
+
+Pass `CONFIG=Debug` (or another multi-config preset) to request a different build configuration in the same command, e.g. `just rive_ndi_win CONFIG=Debug`. The build directory layout keeps the NDI workflow isolated from any default `build` artifacts while enabling you to open `build/rive_ndi/yup.sln` in Visual Studio for further work if desired.
+
+## Follow-up steps
+
+* **Iterate on code changes:** Re-run `cmake --build build/rive_ndi --target yup --config Release` (adjusting `--config` if you chose a different variant) after editing C++ or binding sources to rebuild quickly.
+* **Run focused tests:** Once the Python wheel is produced you can execute Windows-side validation such as `py -m pytest` from the `python` folder (after installing the generated wheel) to confirm bindings behave as expected.
+* **Package or publish:** When you need an updated wheel artifact, run `cmake --build build/rive_ndi --target yup --config Release` followed by `just python_wheel` (from the repo root) to regenerate and install/test the wheel using the same configuration.
+* **Re-enable audio later:** If you need the full audio toolchain again, reconfigure with `-DYUP_ENABLE_AUDIO_MODULES=ON` (or omit the override entirely) and rerun the build command.
+
+By consistently using `build/rive_ndi` you avoid cross-contaminating other build flavours while keeping the Direct3D/NDI toolchain reproducible.

--- a/justfile
+++ b/justfile
@@ -59,6 +59,12 @@ android:
 android:
   cmake -G "Visual Studio 17 2022" -B build -DYUP_TARGET_ANDROID=ON
 
+[doc("configure and build the Windows Rive NDI pipeline wheel (audio disabled)")]
+[windows]
+rive_ndi_win CONFIG="Release":
+  cmake -G "Visual Studio 17 2022" -B build/rive_ndi -DYUP_ENABLE_AUDIO_MODULES=OFF -DYUP_BUILD_WHEEL=ON
+  cmake --build build/rive_ndi --target yup --config {{CONFIG}}
+
 [doc("generate and open project for Android using Android Studio (linux)")]
 [linux]
 android:

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -42,6 +42,22 @@ yup_add_default_modules ("${CMAKE_CURRENT_LIST_DIR}/.."
         YUP_PYTHON_SCRIPT_CATCH_EXCEPTION=0
         PYBIND11_DETAILED_ERROR_MESSAGES=1)
 
+set (wheel_modules
+    yup::yup_core
+    yup::yup_data_model
+    yup::yup_events
+    yup::yup_graphics
+    yup::yup_gui
+    yup::yup_python)
+
+if (YUP_ENABLE_AUDIO_MODULES)
+    set (wheel_modules
+        yup::yup_audio_basics
+        yup::yup_audio_devices
+        yup::yup_audio_processors
+        ${wheel_modules})
+endif()
+
 yup_standalone_app (
     TARGET_NAME ${target_name}
     TARGET_VERSION ${target_version}
@@ -49,16 +65,7 @@ yup_standalone_app (
     TARGET_APP_ID "org.yup.${target_name}"
     TARGET_APP_NAMESPACE "org.yup"
     TARGET_WHEEL ON
-    MODULES
-        yup::yup_audio_basics
-        yup::yup_audio_devices
-        yup::yup_audio_processors
-        yup::yup_core
-        yup::yup_data_model
-        yup::yup_events
-        yup::yup_graphics
-        yup::yup_gui
-        yup::yup_python)
+    MODULES ${wheel_modules})
 
 set_target_properties (${target_name} PROPERTIES
     CXX_EXTENSIONS OFF


### PR DESCRIPTION
## Summary
- add a `YUP_ENABLE_AUDIO_MODULES` toggle and use it to skip registering audio components when disabled
- ensure the Python wheel only requests audio modules when they are available
- refresh the Windows Rive NDI recipe and docs to highlight the audio toggle and configuration options

## Testing
- just --list *(fails: `just` is not installed in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d2bc24c5508329b266ebf71b68c2c1