### PR TITLE
Add audio module toggle support for Python packaging

### DIFF
--- a/cmake/yup_modules.cmake
+++ b/cmake/yup_modules.cmake
@@ -616,6 +616,12 @@ macro (yup_add_default_modules modules_path)
     _yup_set_default (YUP_ARG_ENABLE_AUDIO ${YUP_ENABLE_AUDIO_MODULES})
     set (modules_definitions "${YUP_ARG_DEFINITIONS}")
 
+    if (YUP_ARG_ENABLE_AUDIO)
+        list (APPEND modules_definitions YUP_ENABLE_AUDIO_MODULES=1)
+    else()
+        list (APPEND modules_definitions YUP_ENABLE_AUDIO_MODULES=0)
+    endif()
+
     # ==== Thirdparty modules
     set (thirdparty_group "Thirdparty")
     yup_add_module (${modules_path}/thirdparty/zlib "${modules_definitions}" ${thirdparty_group})

--- a/docs/Rive to NDI Guide.md
+++ b/docs/Rive to NDI Guide.md
@@ -5,4 +5,7 @@ This guide is being prepared to document the workflow for streaming Rive animati
 > [!NOTE]
 > When configuring with `-DYUP_ENABLE_AUDIO_MODULES=OFF`, YUP automatically skips the audio-dependent console, app, graphics, and plugin samples as well as the CTest suite. This keeps the slimmed-down Rive→NDI workflow free from audio build requirements.
 
+> [!TIP]
+> Python wheels honour the same toggle. Set `YUP_ENABLE_AUDIO_MODULES=0` in your environment before running `python -m build python` (or `pip wheel`) to publish artifacts that exclude the audio stack. Switch it back to `1` if a consumer explicitly needs the legacy audio APIs.
+
 Additional sections covering renderer setup, Python bindings, and NDI orchestration will be added soon.

--- a/docs/rive_ndi_overview.md
+++ b/docs/rive_ndi_overview.md
@@ -35,6 +35,24 @@ cmake -S . -B build-rive-ndi-win \
 
 These flags trim unrelated subsystems and speed up compilation while you iterate on the renderer, bindings, and NDI layer. Additional feature toggles can stay at their defaults unless you need them for debugging.
 
+### Audio Module Toggle
+
+The renderer/NDI stack stays leanest when the legacy audio toolchain is excluded. Set `YUP_ENABLE_AUDIO_MODULES=OFF` at configure time to keep the build focused on graphics and Python:
+
+```bash
+cmake -S . -B build-rive-ndi-win \
+  -DYUP_ENABLE_AUDIO_MODULES=OFF
+```
+
+Python wheel builds respect the same switch via an environment variable. When creating artifacts for automation hosts, export the variable before invoking `pip` or `python -m build`:
+
+```bash
+set YUP_ENABLE_AUDIO_MODULES=0
+python -m build python
+```
+
+Use `1` to re-enable the audio modules if a downstream integration actually needs them.
+
 ## Streamlined Commands
 A `just rive_ndi_win` recipe (landing soon in the project `justfile`) will encapsulate the configuration and build steps above, plus invoke targeted tests for the renderer/binding/NDI stack. Once available, run:
 

--- a/modules/yup_core/yup_core.h
+++ b/modules/yup_core/yup_core.h
@@ -175,6 +175,15 @@
 #define YUP_ALLOW_STATIC_NULL_VARIABLES 0
 #endif
 
+/** Config: YUP_ENABLE_AUDIO_MODULES
+    Controls whether audio-related modules are compiled and registered at build time.
+    This flag is normally provided by the build system and defaults to enabled when
+    audio modules are available.
+*/
+#ifndef YUP_ENABLE_AUDIO_MODULES
+#define YUP_ENABLE_AUDIO_MODULES 1
+#endif
+
 /** Config: YUP_STRICT_REFCOUNTEDPOINTER
     If enabled, this will make the ReferenceCountedObjectPtr class stricter about allowing
     itself to be cast directly to a raw pointer. By default this is disabled, for compatibility

--- a/modules/yup_gui/themes/theme_v1/yup_ThemeVersion1.cpp
+++ b/modules/yup_gui/themes/theme_v1/yup_ThemeVersion1.cpp
@@ -19,7 +19,7 @@
   ==============================================================================
 */
 
-#if YUP_MODULE_AVAILABLE_yup_audio_gui
+#if YUP_ENABLE_AUDIO_MODULES && YUP_MODULE_AVAILABLE_yup_audio_gui
 #include <yup_audio_gui/yup_audio_gui.h>
 #endif
 
@@ -768,7 +768,7 @@ void paintPopupMenu (Graphics& g, const ApplicationTheme& theme, const PopupMenu
 }
 
 //==============================================================================
-#if YUP_MODULE_AVAILABLE_yup_audio_gui
+#if YUP_ENABLE_AUDIO_MODULES && YUP_MODULE_AVAILABLE_yup_audio_gui
 void paintMidiKeyboard (Graphics& g, const ApplicationTheme& theme, const MidiKeyboardComponent& keyboard)
 {
     auto bounds = keyboard.getLocalBounds();
@@ -983,7 +983,7 @@ ApplicationTheme::Ptr createThemeVersion1()
 
     theme->setComponentStyle<PopupMenu> (ComponentStyle::createStyle<PopupMenu> (paintPopupMenu));
 
-#if YUP_MODULE_AVAILABLE_yup_audio_gui
+#if YUP_ENABLE_AUDIO_MODULES && YUP_MODULE_AVAILABLE_yup_audio_gui
     theme->setComponentStyle<MidiKeyboardComponent> (ComponentStyle::createStyle<MidiKeyboardComponent> (paintMidiKeyboard));
     theme->setColor (MidiKeyboardComponent::Style::whiteKeyColorId, Color (0xfff0f0f0));
     theme->setColor (MidiKeyboardComponent::Style::whiteKeyPressedColorId, Color (0xff4ebfff));

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -30,21 +30,6 @@ set (target_name yup)
 set (target_version ${yup_version})
 project (${target_name} VERSION ${target_version})
 
-set (python_modules
-    yup::yup_core
-    yup::yup_data_model
-    yup::yup_events
-    yup::yup_graphics
-    yup::yup_gui
-    yup::yup_python)
-
-if (YUP_ENABLE_AUDIO_MODULES)
-    list (PREPEND python_modules
-        yup::yup_audio_basics
-        yup::yup_audio_devices
-        yup::yup_audio_processors)
-endif()
-
 yup_add_default_modules ("${CMAKE_CURRENT_LIST_DIR}/.."
     ENABLE_PYTHON ON
     ENABLE_AUDIO ${YUP_ENABLE_AUDIO_MODULES}
@@ -61,6 +46,30 @@ yup_add_default_modules ("${CMAKE_CURRENT_LIST_DIR}/.."
         YUP_PYTHON_EMBEDDED_INTERPRETER=0
         YUP_PYTHON_SCRIPT_CATCH_EXCEPTION=0
         PYBIND11_DETAILED_ERROR_MESSAGES=1)
+
+set (python_modules
+    yup::yup_core
+    yup::yup_data_model
+    yup::yup_events
+    yup::yup_graphics
+    yup::yup_gui
+    yup::yup_python)
+
+set (audio_module_targets
+    yup_audio_basics
+    yup_audio_devices
+    yup_audio_processors)
+
+set (available_audio_modules)
+foreach (audio_module IN LISTS audio_module_targets)
+    if (TARGET ${audio_module})
+        list (APPEND available_audio_modules "yup::${audio_module}")
+    endif()
+endforeach()
+
+if (available_audio_modules)
+    list (PREPEND python_modules ${available_audio_modules})
+endif()
 
 yup_standalone_app (
     TARGET_NAME ${target_name}

--- a/python/setup.py
+++ b/python/setup.py
@@ -87,6 +87,7 @@ class CMakeBuildExtension(build_ext):
     build_with_lto = get_environment_option(int, "YUP_ENABLE_LTO", 0)
     build_osx_architectures = get_environment_option(str, "YUP_OSX_ARCHITECTURES", "arm64")
     build_osx_deployment_target = get_environment_option(str, "YUP_OSX_DEPLOYMENT_TARGET", "11.0")
+    build_enable_audio_modules = get_environment_option(int, "YUP_ENABLE_AUDIO_MODULES", 1)
 
     def build_extension(self, ext):
         log.info("building with cmake")
@@ -114,6 +115,10 @@ class CMakeBuildExtension(build_ext):
             f"-DPython_ROOT_DIR:PATH={sys.exec_prefix}",
             f"-DPython_INCLUDE_DIRS:PATH={get_python_includes_path()}",
             f"-DPython_LIBRARY_DIRS:PATH={get_python_lib_path()}"
+        ]
+
+        cmake_args += [
+            f"-DYUP_ENABLE_AUDIO_MODULES:BOOL={'ON' if self.build_enable_audio_modules else 'OFF'}",
         ]
 
         if platform.system() == 'Darwin':


### PR DESCRIPTION
## Summary
- define a build-wide `YUP_ENABLE_AUDIO_MODULES` toggle and propagate it through the default module setup and GUI theme so audio widgets are skipped when disabled
- make the Python wheel configuration honour the audio toggle and only link audio modules when they are actually built
- refresh the Windows Rive→NDI documentation to explain the audio toggle for both CMake and Python packaging workflows

## Testing
- not run (configuration-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d2cadf36c8832985261e122c47fb8b