### PR TITLE
Add renderer/NDI smoke tests and update Windows workflow docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,57 +1,53 @@
 # Coding Agent Guide: GPU-Accelerated Rive Renderer with NDI Output
 
 ## Mission Overview
-You are extending YUP to deliver a Windows-focused pipeline that renders Rive (.riv) animations offscreen via Direct3D 11 and exposes frames (with alpha) to Python for NDI transmission. The end result is a reusable C++ core (built with CMake/Visual Studio), a pybind11-powered Python module, and a lightweight Python control layer that can drive NDI streams and optional REST/OSC endpoints. Audio/plugin subsystems in YUP remain untouched and disabled at runtime.
+You are extending YUP to deliver a Windows-focused pipeline that renders Rive (`.riv`) animations offscreen via Direct3D 11 and exposes frames (with alpha) to Python for NDI transmission. The end result is a reusable C++ core (built with CMake/Visual Studio), a pybind11-powered Python module, and a lightweight Python control layer that can drive NDI streams and optional REST/OSC endpoints. Audio/plugin subsystems in YUP remain untouched and disabled at runtime.
 
-### Key Objectives
-1. **C++ Offscreen Renderer**: Maintain or extend `yup::RiveOffscreenRenderer` (or a sibling module) to initialise a D3D11 device without a swap chain, render artboards into a BGRA texture, and provide fast CPU readback.
-2. **Rive Animation Control**: Build a wrapper that loads .riv files, manages artboards/animations/state machines, and coordinates frame advancement with rendering.
-3. **Python Bindings**: Expose the renderer/animation engine through pybind11 (module name TBD, e.g. `yup_rive_renderer`) with ergonomic methods for animation control and frame retrieval.
-4. **NDI Streaming Layer**: Implement Python orchestration that consumes BGRA frames and publishes them via cyndilib’s `Sender`, supporting multi-instance operation and optional REST/OSC control.
-5. **Windows Tooling**: Ensure all CMake targets and build scripts work with MSVC 2022, C++17, and the Windows 10/11 SDK. Other platforms are secondary.
+**Supported platform:** Windows 11 with MSVC 2022 and the Windows 10/11 SDK. Other platforms may compile stub implementations, but only Windows requires full functionality.
 
-Keep these objectives in mind while navigating the codebase; most of YUP is unrelated to this pipeline.
+## Implementation Snapshot (April 2025)
+| Area | Status | Key Files |
+| --- | --- | --- |
+| Direct3D 11 offscreen renderer | ✅ `yup::RiveOffscreenRenderer` initialises the D3D11 device/context, renders into a BGRA texture, and performs CPU readback into a shared buffer. | `modules/yup_gui/artboard/yup_RiveOffscreenRenderer.h/.cpp` |
+| Scene & animation control | ✅ Artboard enumeration, animation/state-machine playback, pause toggling, and state-machine input helpers are exposed through the renderer API. | `modules/yup_gui/artboard/yup_RiveOffscreenRenderer.cpp` |
+| Renderer tests | ✅ GoogleTest coverage validates frame stride/dimensions, pause semantics, shared-buffer behaviour, and artboard switching. | `tests/yup_gui/yup_RiveOffscreenRenderer.cpp` |
+| Python renderer binding | ✅ `yup_rive_renderer` pybind11 module wraps renderer construction, artboard/animation APIs, and exposes zero-copy frame views. | `python/src/yup_rive_renderer.cpp`, build glue in `python/CMakeLists.txt`, packaging metadata in `python/pyproject.toml` |
+| Python NDI orchestration | ✅ `yup_ndi` package manages multi-stream orchestration, timestamp mapping, metadata dispatch, and optional control hooks using mocked `cyndilib` senders for tests. | `python/yup_ndi/__init__.py`, `python/yup_ndi/orchestrator.py`, tests under `python/tests/test_yup_ndi/` |
+| Python test harness | ✅ `pytest` suites cover binding behaviour, orchestrator frame flow, and provide fake renderer/sender utilities that avoid native DLL requirements. | `python/tests/` |
+| Documentation & developer workflow | ⚠️ Needs expansion in `docs/` and `tools/` to describe Windows build steps, wheel packaging, and orchestration usage. |
 
-## Repository Map (Relevant Areas)
-| Path | Why it matters |
-| --- | --- |
-| `modules/yup_gui/artboard/yup_RiveOffscreenRenderer.h/.cpp` | Existing offscreen renderer skeleton. Extend/refactor here to fulfil the D3D11 BGRA rendering and readback requirements. |
-| `modules/yup_gui/component/` | Hosts higher-level GUI abstractions; only touch if you need factory hooks or resource loading helpers for Rive. |
-| `modules/yup_graphics/` | Low-level graphics helpers (textures, render contexts). Useful when wiring Direct3D resources or reusing YUP utilities. |
-| `modules/yup_core/` & `modules/yup_events/` | General utilities (timers, logging, threading). Reuse when building engine support code. |
-| `python/CMakeLists.txt` & `python/pyproject.toml` | Starting points for configuring the pybind11 extension and packaging the Python module. |
-| `python/tests/` | Place or adapt tests that validate the Python binding and NDI integration stubs. |
-| `tools/` | Contains build scripts and helper utilities; add new tooling (e.g., packaging commands) if necessary. |
-| `examples/render/` | Reference for how YUP currently integrates Rive; use for implementation hints but do not modify unless creating dedicated demos. |
+## Key Components & File Map
+- **Renderer core:** `modules/yup_gui/artboard/yup_RiveOffscreenRenderer.h/.cpp`
+  - D3D11 setup, staging texture readback, artboard/animation/state-machine management, pause controls, and frame-buffer accessors.
+  - Non-Windows fallback stub maintains API compatibility but reports unsupported status.
+- **Supporting tests:** `tests/yup_gui/yup_RiveOffscreenRenderer.cpp`
+  - Exercises pause toggling, buffer sharing, stride validation, and artboard selection across stubbed renderers.
+- **Python binding:** `python/src/yup_rive_renderer.cpp`
+  - Binds renderer lifecycle, exposes artboard lists, playback controls, state-machine inputs, and `memoryview`-friendly BGRA buffers.
+  - Build definitions live in `python/CMakeLists.txt`; packaging metadata in `python/pyproject.toml` targets MSVC 2022 + C++17 with Ninja.
+- **Python orchestration:** `python/yup_ndi/orchestrator.py`
+  - Implements `RiveStreamOrchestrator`, stream configuration dataclasses, metadata callbacks, REST/OSC hook placeholders, and stream lifecycle management.
+  - Package entry point re-exports live in `python/yup_ndi/__init__.py`.
+- **Python tests & utilities:**
+  - `python/tests/test_yup_ndi/test_orchestrator.py` supplies orchestrator coverage with fake renderer/sender fixtures.
+  - `python/tests/common.py`, `python/tests/utilities.py`, and `python/tests/conftest.py` provide shared helpers and dependency guards when the native extension is unavailable.
+- **Packaging scaffold:** `python/setup.py`, `python/MANIFEST.in`, and `python/tools/` for Windows wheel generation (needs auditing as work continues).
 
-### Out-of-Scope / Mostly Redundant for This Project
-- `modules/yup_audio/*`, `modules/yup_plugin/*`: Audio/plugin layers should remain untouched.
-- `examples/audio/*`, `examples/plugins/*`: Skip unless documenting non-changes.
-- `thirdparty/` contents: Treat as vendor code—do not edit.
-- Platform builds other than Windows: keep existing settings but avoid platform-specific churn.
+## Current Priorities
+1. **Documentation & developer tooling**
+   - Expand `docs/` with Windows 11 build instructions for the renderer, Python binding, and NDI orchestrator usage.
+   - Update `justfile` or add scripts in `tools/` describing end-to-end workflows (configure VS environment, build wheel, run tests).
+2. **Integration testing**
+   - Plan combined smoke tests that exercise the pybind11 module feeding the orchestrator (mocks acceptable for automation; document manual NDI validation).
+3. **Performance validation**
+   - Profile frame throughput and ensure zero-copy semantics across the renderer → Python boundary when running on Windows hardware.
 
 ## Workflow Expectations
-- Maintain modular design: isolate the D3D11 renderer, animation logic, Python binding, and NDI orchestrator into clear components with minimal coupling.
-- Prefer extending existing facilities over reinventing them (e.g., reuse `RiveOffscreenRenderer` scaffolding, CMake helper functions, and logging macros).
-- Document behaviour and assumptions inline (especially around GPU resource lifetimes and frame timing).
-- Add targeted tests (C++ or Python) to cover frame generation, animation advancement, and binding correctness. If NDI cannot be exercised in CI, stub or mock responsibly and note manual validation steps.
-- Leave unrelated subsystems exactly as they are; avoid incidental formatting or drive-by refactors outside the scope above.
+- **Analyse before coding:** survey existing helpers (e.g., `modules/yup_graphics/`, `modules/yup_core/`) before introducing new abstractions; reuse utilities whenever possible.
+- **Code style:** adhere to Allman braces, JUCE-style naming, and include-order conventions outlined in `CLAUDE.md`. Add Doxygen for new public APIs.
+- **Error handling:** use RAII for graphics resources, propagate detailed errors through `RiveOffscreenRenderer::getLastError()` and mirror them in Python exceptions.
+- **Testing:** accompany new functionality with deterministic GoogleTests or `pytest` cases. Provide mocks when native dependencies (NDI, GPU) are unavailable in CI.
+- **Windows focus:** keep build flags, documentation, and scripts aligned with Windows 11 + MSVC 2022; non-Windows paths should remain stubs without extra investment.
+- **Change scope:** keep commits targeted—avoid formatting-only edits and unrelated subsystem changes.
 
-
-## Coding Standards (See also `CLAUDE.md`)
-- **File headers**: Every new C++ source or header file must begin with the canonical YUP comment block defined in `CLAUDE.md`. Do not omit or alter the wording.
-- **Formatting**: Follow Allman brace style for classes, functions, and control structures. Keep indentation consistent with existing code.
-- **Naming**: Use PascalCase for classes, camelCase for functions, variables, and constants. Keep one primary class per file (`yup_ClassName.h/.cpp`).
-- **Includes & guards**: Honour the include order guidance in `CLAUDE.md`, and prefer `#pragma once` in headers.
-- **Const-correctness & RAII**: Prefer immutable interfaces where possible, wrap resources in RAII helpers, and use YUP `Result`/`ResultValue` patterns for fallible operations.
-- **Documentation**: Provide meaningful Doxygen comments for any new public API you surface in C++ or Python bindings.
-- **Testing**: When adding tests, focus on public interfaces, keep them deterministic, and use `just test` (or the project’s documented equivalent) to execute them when requested.
-- **Platform guards**: Wrap platform-specific code with the `YUP_*` macros outlined in `CLAUDE.md`.
-- **String & optional utilities**: Prefer `yup::String`, `std::optional`, and other YUP-standard abstractions when handling dynamic values.
-
-## Communication Notes
-- When creating pull requests or status updates, always tie progress back to the objectives listed here (renderer, animation engine, Python binding, NDI layer, Windows build support).
-- Call out dependencies or configuration changes that impact Visual Studio builds or Python packaging so downstream consumers can adjust quickly.
-
-Stay focused on the GPU-accelerated Rive rendering pipeline and keep the footprint of changes tight within the mapped areas.
-
+Stay focused on delivering a polished Windows pipeline from Rive rendering through Python-based NDI streaming while maintaining clear documentation for future contributors.

--- a/docs/Rive to NDI Guide.md
+++ b/docs/Rive to NDI Guide.md
@@ -1,6 +1,6 @@
 # Rive → NDI Pipeline Guide (Preview)
 
-This guide is being prepared to document the workflow for streaming Rive animations to NDI using the YUP toolchain.
+This guide documents the concrete workflow for streaming Rive animations to NDI using the Windows-focused YUP toolchain.
 
 > [!NOTE]
 > When configuring with `-DYUP_ENABLE_AUDIO_MODULES=OFF`, YUP automatically skips the audio-dependent console, app, graphics, and plugin samples as well as the CTest suite. This keeps the slimmed-down Rive→NDI workflow free from audio build requirements.
@@ -8,4 +8,83 @@ This guide is being prepared to document the workflow for streaming Rive animati
 > [!TIP]
 > Python wheels honour the same toggle. Set `YUP_ENABLE_AUDIO_MODULES=0` in your environment before running `python -m build python` (or `pip wheel`) to publish artifacts that exclude the audio stack. Switch it back to `1` if a consumer explicitly needs the legacy audio APIs.
 
-Additional sections covering renderer setup, Python bindings, and NDI orchestration will be added soon.
+## 1. Build the Direct3D 11 renderer (Windows 11)
+
+The offscreen renderer implementation lives in `modules/yup_gui/artboard/yup_RiveOffscreenRenderer.h/.cpp`. Configure and build only the graphics-focused targets with MSVC 2022:
+
+```powershell
+cmake -S . -B build/rive-ndi-win `
+  -G "Visual Studio 17 2022" `
+  -DYUP_ENABLE_AUDIO_MODULES=OFF `
+  -DYUP_ENABLE_PLUGIN_MODULES=OFF `
+  -DYUP_ENABLE_EXAMPLES=OFF
+
+cmake --build build/rive-ndi-win --target yup_gui --config RelWithDebInfo
+```
+
+This generates the Direct3D renderer used by both the C++ tests (`tests/yup_gui/yup_RiveOffscreenRenderer.cpp`) and the Python binding.
+
+## 2. Compile the Python bindings and wheel
+
+The pybind11 module lives at `python/src/yup_rive_renderer.cpp` with build glue in `python/CMakeLists.txt` and packaging metadata in `python/pyproject.toml`.
+
+```powershell
+cmake -S python -B build/rive-ndi-win-python `
+  -G "Visual Studio 17 2022" `
+  -DYUP_ENABLE_AUDIO_MODULES=OFF
+
+cmake --build build/rive-ndi-win-python --target yup_rive_renderer --config RelWithDebInfo
+cmake --build build/rive-ndi-win-python --target yup --config RelWithDebInfo
+
+cd python
+python -m build --wheel
+python -m pip install --force-reinstall dist/yup-*.whl
+cd ..
+```
+
+Installing the freshly built wheel makes the `yup_rive_renderer` module importable for the orchestration tests.
+
+## 3. Run the renderer ↔︎ NDI smoke tests
+
+Targeted pytest coverage now verifies the binding, frame acquisition, and orchestration logic:
+
+```powershell
+just python_test_rive_ndi
+```
+
+This recipe runs the suites under `python/tests/test_yup_rive_renderer/` (binding construction, zero-copy frame views) and `python/tests/test_yup_ndi/` (mocked renderers + NDI senders, timestamp mapping, and control flows). Each test is guarded to skip gracefully if the native modules are unavailable on non-Windows hosts.
+
+## 4. Launch orchestrated streams
+
+With the wheel installed, integrate the orchestrator from `python/yup_ndi/orchestrator.py` into your automation tooling. The entry points under `python/yup_ndi/__init__.py` expose `NDIOrchestrator` and `NDIStreamConfig`. Example usage:
+
+```python
+from yup_ndi import NDIOrchestrator, NDIStreamConfig
+
+config = NDIStreamConfig(
+    name="showcase",
+    width=1920,
+    height=1080,
+    riv_path=r"C:\\assets\\title.riv",
+    animation="intro",
+    metadata={"ndi": {"scene": "title"}},
+)
+
+with NDIOrchestrator() as orchestrator:
+    orchestrator.add_stream(config)
+    orchestrator.advance_stream("showcase", 1 / 60)
+```
+
+The orchestrator accepts optional REST/OSC control hooks and multiple concurrent streams; see the in-line documentation for the `NDIStreamConfig` dataclass and the `_NDIStream` helper.
+
+## Reference locations
+
+| Component | Files |
+| --- | --- |
+| Renderer implementation | `modules/yup_gui/artboard/yup_RiveOffscreenRenderer.h/.cpp` |
+| Renderer unit tests | `tests/yup_gui/yup_RiveOffscreenRenderer.cpp` |
+| Python binding | `python/src/yup_rive_renderer.cpp` + `python/CMakeLists.txt` |
+| Python orchestration | `python/yup_ndi/orchestrator.py` + `python/yup_ndi/__init__.py` |
+| Python smoke tests | `python/tests/test_yup_rive_renderer/`, `python/tests/test_yup_ndi/` |
+
+By following the sequence above you can build, package, and validate the Windows-only pipeline without touching unrelated modules.

--- a/justfile
+++ b/justfile
@@ -97,3 +97,8 @@ python_uninstall:
 [working-directory: 'python']
 python_test *TEST_OPTS:
   python -m pytest -s {{TEST_OPTS}}
+
+[working-directory: 'python']
+[doc("run renderer and NDI focused python smoke tests")]
+python_test_rive_ndi:
+  python -m pytest -q tests/test_yup_rive_renderer tests/test_yup_ndi

--- a/modules/yup_gui/artboard/yup_RiveOffscreenRenderer.cpp
+++ b/modules/yup_gui/artboard/yup_RiveOffscreenRenderer.cpp
@@ -41,6 +41,7 @@
 #include "rive/layout.hpp"
 #include "rive/animation/linear_animation_instance.hpp"
 #include "rive/animation/state_machine_instance.hpp"
+#include "rive/static_scene.hpp"
 #include "rive/renderer/d3d/d3d.hpp"
 #include "rive/renderer/d3d11/render_context_d3d_impl.hpp"
 #include "rive/renderer/rive_renderer.hpp"
@@ -130,12 +131,20 @@ struct RiveOffscreenRenderer::Impl
     Result loadInternal (const std::function<ArtboardFile::LoadResult (rive::Factory&)>& loader,
                          const String& artboardName)
     {
+        lastError.clear();
+
+        const auto failWith = [this] (String message)
+        {
+            lastError = std::move (message);
+            return Result::fail (lastError);
+        };
+
         if (! initialised)
-            return Result::fail ("Rive offscreen renderer is not available");
+            return failWith ("Rive offscreen renderer is not available");
 
         auto factory = renderContext->factory();
         if (factory == nullptr)
-            return Result::fail ("Missing Rive factory");
+            return failWith ("Missing Rive factory");
 
         auto loadResult = loader (*factory);
         if (! loadResult)
@@ -146,9 +155,33 @@ struct RiveOffscreenRenderer::Impl
 
         artboardFile = loadResult.getValue();
 
+        return selectArtboardInternal (artboardName);
+    }
+
+    Result selectArtboard (const String& artboardName)
+    {
+        lastError.clear();
+
+        return selectArtboardInternal (artboardName);
+    }
+
+    Result selectArtboardInternal (const String& artboardName)
+    {
+        const auto failWith = [this] (String message)
+        {
+            lastError = std::move (message);
+            return Result::fail (lastError);
+        };
+
+        if (! initialised)
+            return failWith ("Rive offscreen renderer is not available");
+
+        if (artboardFile == nullptr)
+            return failWith ("No Rive file has been loaded");
+
         auto* riveFile = artboardFile->getRiveFile();
         if (riveFile == nullptr)
-            return Result::fail ("Loaded Rive file is invalid");
+            return failWith ("Loaded Rive file is invalid");
 
         std::unique_ptr<rive::ArtboardInstance> loadedArtboard;
 
@@ -158,25 +191,32 @@ struct RiveOffscreenRenderer::Impl
             loadedArtboard = riveFile->artboardDefault();
 
         if (loadedArtboard == nullptr)
-            return Result::fail ("Unable to create artboard instance");
-
-        artboard = std::move (loadedArtboard);
-        updateViewTransform();
-
-        resetScenes();
-
-        if (! scene)
-            return Result::fail ("Artboard does not contain a playable scene");
-
         {
-            std::scoped_lock lock (frameMutex);
-            frameSnapshot.reset();
-            frameSnapshotDirty = true;
+            if (artboardName.isNotEmpty())
+                return failWith ("Unable to find artboard named '" + artboardName + "'");
+
+            return failWith ("Rive file does not contain a default artboard");
         }
 
-        scene->advanceAndApply (0.0f);
-        renderFrame();
-        return Result::ok();
+        return setActiveArtboard (std::move (loadedArtboard));
+    }
+
+    StringArray listArtboards() const
+    {
+        StringArray names;
+
+        if (artboardFile == nullptr)
+            return names;
+
+        if (auto* riveFile = artboardFile->getRiveFile())
+        {
+            const auto artboardCount = riveFile->artboardCount();
+
+            for (std::size_t index = 0; index < artboardCount; ++index)
+                names.add (String (riveFile->artboardNameAt (index)));
+        }
+
+        return names;
     }
 
     StringArray listAnimations() const
@@ -229,6 +269,8 @@ struct RiveOffscreenRenderer::Impl
         animation->loopValue (loop ? static_cast<int> (rive::Loop::loop) : static_cast<int> (rive::Loop::oneShot));
         scene = animation.get();
         scene->advanceAndApply (0.0f);
+        paused = false;
+        renderFrame();
         return true;
     }
 
@@ -247,6 +289,8 @@ struct RiveOffscreenRenderer::Impl
 
         scene = stateMachine.get();
         scene->advanceAndApply (0.0f);
+        paused = false;
+        renderFrame();
         return true;
     }
 
@@ -256,6 +300,7 @@ struct RiveOffscreenRenderer::Impl
         stateMachine.reset();
         sceneHolder.reset();
         scene = nullptr;
+        paused = false;
     }
 
     bool setBoolInput (const String& name, bool value)
@@ -329,6 +374,8 @@ private:
     void initialise()
     {
         using Microsoft::WRL::ComPtr;
+
+        lastError.clear();
 
         UINT creationFlags = D3D11_CREATE_DEVICE_BGRA_SUPPORT;
 #if YUP_DEBUG
@@ -408,7 +455,19 @@ private:
         if (artboard != nullptr)
             sceneHolder = artboard->defaultScene();
 
+        if (sceneHolder == nullptr && artboard != nullptr)
+            sceneHolder = std::make_unique<rive::StaticScene> (artboard.get());
+
         scene = sceneHolder.get();
+
+        if (scene != nullptr)
+        {
+            if (dynamic_cast<rive::StateMachineInstance*> (scene) != nullptr)
+            {
+                stateMachine.reset (static_cast<rive::StateMachineInstance*> (sceneHolder.release()));
+                scene = stateMachine.get();
+            }
+        }
     }
 
     void updateViewTransform()
@@ -497,6 +556,7 @@ private:
     rive::Mat2D viewTransform = rive::Mat2D::identity();
 
     String lastError;
+    String activeArtboardName;
 
     int width = 0;
     int height = 0;
@@ -525,6 +585,41 @@ private:
 
         return frameSnapshot;
     }
+
+    Result setActiveArtboard (std::unique_ptr<rive::ArtboardInstance> newArtboard)
+    {
+        if (newArtboard == nullptr)
+            return Result::fail ("Artboard instance is invalid");
+
+        artboard = std::move (newArtboard);
+        activeArtboardName = String (artboard->name());
+
+        updateViewTransform();
+        resetScenes();
+
+        if (scene == nullptr)
+            return Result::fail ("Artboard does not contain a playable scene");
+
+        paused = false;
+
+        {
+            std::scoped_lock lock (frameMutex);
+            frameSnapshot.reset();
+            frameSnapshotDirty = true;
+        }
+
+        scene->advanceAndApply (0.0f);
+        renderFrame();
+
+        return Result::ok();
+    }
+
+    String getActiveArtboardName() const
+    {
+        return activeArtboardName;
+    }
+
+    Microsoft::WRL::ComPtr<ID3D11Device> device;
 };
 
 } // namespace yup
@@ -556,28 +651,37 @@ struct RiveOffscreenRenderer::Impl
         return Result::fail (lastError);
     }
 
+    StringArray listArtboards() const { return {}; }
     StringArray listAnimations() const { return {}; }
     StringArray listStateMachines() const { return {}; }
     bool playAnimation (const String&, bool) { return false; }
     bool playStateMachine (const String&) { return false; }
-    void stop() {}
+    void stop() { paused = false; }
     bool setBoolInput (const String&, bool) { return false; }
     bool setNumberInput (const String&, double) { return false; }
     bool fireTrigger (const String&) { return false; }
     bool advance (float) { return false; }
-    void setPaused (bool) {}
-    bool isPaused() const noexcept { return false; }
+    void setPaused (bool shouldPause) { paused = shouldPause; }
+    bool isPaused() const noexcept { return paused; }
     int getWidth() const noexcept { return width; }
     int getHeight() const noexcept { return height; }
     std::size_t getStride() const noexcept { return static_cast<std::size_t> (width) * 4u; }
     const std::vector<uint8>& getFrameBuffer() const noexcept { return *frameBuffer; }
     std::shared_ptr<const std::vector<uint8>> getFrameBufferShared() const noexcept { return frameBuffer; }
     const String& getLastError() const noexcept { return lastError; }
+    Result selectArtboard (const String& name)
+    {
+        (void) name;
+        lastError = "Direct3D11 offscreen rendering is only available on Windows";
+        return Result::fail (lastError);
+    }
+    String getActiveArtboardName() const { return {}; }
 
     int width = 0;
     int height = 0;
     std::shared_ptr<std::vector<uint8>> frameBuffer;
     String lastError;
+    bool paused = false;
 };
 
 } // namespace yup
@@ -609,6 +713,11 @@ Result RiveOffscreenRenderer::loadFromBytes (Span<const uint8> bytes, const Stri
     return impl->load (bytes, artboardName);
 }
 
+StringArray RiveOffscreenRenderer::listArtboards() const
+{
+    return impl->listArtboards();
+}
+
 StringArray RiveOffscreenRenderer::listAnimations() const
 {
     return impl->listAnimations();
@@ -627,6 +736,11 @@ bool RiveOffscreenRenderer::playAnimation (const String& animationName, bool sho
 bool RiveOffscreenRenderer::playStateMachine (const String& machineName)
 {
     return impl->playStateMachine (machineName);
+}
+
+Result RiveOffscreenRenderer::selectArtboard (const String& artboardName)
+{
+    return impl->selectArtboard (artboardName);
 }
 
 void RiveOffscreenRenderer::stop()
@@ -692,6 +806,11 @@ std::shared_ptr<const std::vector<uint8>> RiveOffscreenRenderer::getFrameBufferS
 const String& RiveOffscreenRenderer::getLastError() const noexcept
 {
     return impl->getLastError();
+}
+
+String RiveOffscreenRenderer::getActiveArtboardName() const
+{
+    return impl->getActiveArtboardName();
 }
 
 } // namespace yup

--- a/modules/yup_gui/artboard/yup_RiveOffscreenRenderer.h
+++ b/modules/yup_gui/artboard/yup_RiveOffscreenRenderer.h
@@ -56,11 +56,20 @@ public:
     /** Loads a Rive file from an in-memory buffer. */
     Result loadFromBytes (Span<const uint8> bytes, const String& artboardName = {});
 
+    /** Lists the available artboards in the currently loaded file. */
+    StringArray listArtboards() const;
+
     /** Lists the available linear animations in the currently loaded artboard. */
     StringArray listAnimations() const;
 
     /** Lists the available state machines in the currently loaded artboard. */
     StringArray listStateMachines() const;
+
+    /** Selects the artboard with the specified name. */
+    Result selectArtboard (const String& artboardName);
+
+    /** Returns the name of the currently active artboard. */
+    String getActiveArtboardName() const;
 
     /** Starts playing the specified linear animation. */
     bool playAnimation (const String& animationName, bool shouldLoop = true);

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -121,3 +121,47 @@ endif()
 
 target_sources (${target_name} PRIVATE
     "${CMAKE_CURRENT_LIST_DIR}/../modules/yup_core/system/yup_StandardHeader.h")
+
+set (rive_renderer_target yup_rive_renderer)
+
+add_library (${rive_renderer_target} MODULE
+    "${CMAKE_CURRENT_LIST_DIR}/src/yup_rive_renderer.cpp")
+
+target_compile_features (${rive_renderer_target} PRIVATE cxx_std_17)
+
+target_compile_definitions (${rive_renderer_target}
+    PRIVATE
+        PYBIND11_DETAILED_ERROR_MESSAGES=1)
+
+target_link_libraries (${rive_renderer_target}
+    PRIVATE
+        yup::yup_core
+        yup::yup_events
+        yup::yup_graphics
+        yup::yup_gui
+        yup::yup_python)
+
+if (TARGET Python::Python)
+    target_link_libraries (${rive_renderer_target} PRIVATE Python::Python)
+endif()
+
+target_include_directories (${rive_renderer_target}
+    PRIVATE
+        "${CMAKE_CURRENT_LIST_DIR}/.."
+        "${Python_INCLUDE_DIRS}")
+
+if (NOT "${Python_LIBRARY_DIRS}" STREQUAL "")
+    target_link_directories (${rive_renderer_target} PRIVATE "${Python_LIBRARY_DIRS}")
+endif()
+
+set_target_properties (${rive_renderer_target} PROPERTIES
+    OUTPUT_NAME "yup_rive_renderer"
+    CXX_EXTENSIONS OFF
+    VISIBILITY_INLINES_HIDDEN TRUE
+    POSITION_INDEPENDENT_CODE TRUE)
+
+if (WIN32)
+    set_target_properties (${rive_renderer_target} PROPERTIES SUFFIX ".pyd")
+else()
+    set_target_properties (${rive_renderer_target} PROPERTIES PREFIX "")
+endif()

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,14 +1,9 @@
 [build-system]
 requires = [
-    # c++ building
-    #"cmake>=3.28",
-    # pyi generation
+    "cmake>=3.28",
+    "ninja",
     "mypy",
-    # unit tests (for code coverage cmake target)
     "pytest",
-    #"numpy",
-    #"imageio",
-    # defaults
     "setuptools",
     "wheel",
 ]
@@ -28,6 +23,9 @@ test-command = "pytest -s {project}/python/tests -vvv"
 manylinux-i686-image = "manylinux_2_28"
 manylinux-x86_64-image = "manylinux_2_28"
 manylinux-aarch64-image = "manylinux_2_28"
+
+[tool.cibuildwheel.windows]
+environment = { "CMAKE_GENERATOR" = "Visual Studio 17 2022", "CMAKE_CXX_STANDARD" = "17" }
 
 [tool.cibuildwheel.linux]
 before-build = [

--- a/python/src/yup_rive_renderer.cpp
+++ b/python/src/yup_rive_renderer.cpp
@@ -1,0 +1,302 @@
+/*
+  ==============================================================================
+
+   This file is part of the YUP library.
+   Copyright (c) 2025 - kunitoki@gmail.com
+
+   YUP is an open source library subject to open-source licensing.
+
+   The code included in this file is provided under the terms of the ISC license
+   http://www.isc.org/downloads/software-support-policy/isc-license. Permission
+   to use, copy, modify, and/or distribute this software for any purpose with or
+   without fee is hereby granted provided that the above copyright notice and
+   this permission notice appear in all copies.
+
+   YUP IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
+   EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
+   DISCLAIMED.
+
+  ==============================================================================
+*/
+
+#define YUP_PYTHON_INCLUDE_PYBIND11_STL
+#define YUP_PYTHON_INCLUDE_PYBIND11_FUNCTIONAL
+#define YUP_PYTHON_INCLUDE_PYBIND11_NUMPY
+#include "modules/yup_python/utilities/yup_PyBind11Includes.h"
+
+#include "modules/yup_core/files/yup_File.h"
+#include "modules/yup_core/misc/yup_Result.h"
+#include "modules/yup_core/containers/yup_Span.h"
+#include "modules/yup_gui/artboard/yup_RiveOffscreenRenderer.h"
+
+#include <cstring>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace yup
+{
+namespace python
+{
+namespace
+{
+    namespace py = pybind11;
+    using namespace pybind11::literals;
+
+    [[noreturn]] void throwResultError (const Result& result)
+    {
+        throw py::value_error (result.getErrorMessage().toStdString());
+    }
+
+    void handleResult (const Result& result)
+    {
+        if (result.failed())
+            throwResultError (result);
+    }
+
+    std::vector<std::string> toStdVector (const StringArray& array)
+    {
+        std::vector<std::string> names;
+        names.reserve (static_cast<std::size_t> (array.size()));
+
+        for (int index = 0; index < array.size(); ++index)
+            names.emplace_back (array[index].toStdString());
+
+        return names;
+    }
+
+    py::memoryview makeFrameMemoryView (const RiveOffscreenRenderer& renderer)
+    {
+        auto frame = renderer.getFrameBufferShared();
+
+        if (! frame || frame->empty() || renderer.getWidth() <= 0 || renderer.getHeight() <= 0)
+        {
+            static uint8 dummy = 0;
+
+            return py::memoryview::from_buffer (
+                &dummy,
+                sizeof (uint8),
+                std::vector<py::ssize_t> { 0 },
+                std::vector<py::ssize_t> { 1 },
+                true);
+        }
+
+        auto* data = const_cast<uint8*> (frame->data());
+        const auto width = static_cast<py::ssize_t> (renderer.getWidth());
+        const auto height = static_cast<py::ssize_t> (renderer.getHeight());
+        const auto stride = static_cast<py::ssize_t> (renderer.getRowStride());
+
+        auto capsule = py::capsule (
+            new std::shared_ptr<const std::vector<uint8>> (frame),
+            [] (void* pointer)
+            {
+                delete reinterpret_cast<std::shared_ptr<const std::vector<uint8>>*> (pointer);
+            });
+
+        return py::memoryview::from_buffer (
+            data,
+            sizeof (uint8),
+            std::vector<py::ssize_t> { height, width, 4 },
+            std::vector<py::ssize_t> { stride, 4, 1 },
+            true,
+            capsule);
+    }
+
+    std::vector<uint8> copyBuffer (py::buffer buffer)
+    {
+        const auto info = buffer.request();
+
+        if (info.ndim != 1)
+            throw py::value_error ("Expected a contiguous 1D buffer of bytes");
+
+        std::vector<uint8> bytes (static_cast<std::size_t> (info.size) * static_cast<std::size_t> (info.itemsize));
+
+        if (! bytes.empty())
+            std::memcpy (bytes.data(), info.ptr, bytes.size());
+
+        return bytes;
+    }
+
+    void bindRiveOffscreenRenderer (py::module_& module)
+    {
+        namespace py = pybind11;
+
+        py::class_<RiveOffscreenRenderer> renderer (
+            module,
+            "RiveOffscreenRenderer",
+            "Direct3D11-backed offscreen renderer for Rive artboards."
+            " Provides animation and state-machine control while exposing BGRA frame"
+            " buffers to Python callers.");
+
+        renderer
+            .def (
+                py::init<int, int>(),
+                "width"_a,
+                "height"_a,
+                "Creates a renderer with the specified output dimensions.")
+            .def (
+                "is_valid",
+                &RiveOffscreenRenderer::isValid,
+                "Returns true when the underlying GPU resources were initialised.")
+            .def (
+                "load_file",
+                [] (RiveOffscreenRenderer& self, const std::string& path, std::optional<std::string> artboard)
+                {
+                    auto result = self.load (File (String (path)), artboard ? String (*artboard) : String());
+                    handleResult (result);
+                },
+                "path"_a,
+                "artboard"_a = std::nullopt,
+                "Loads a .riv file from disk, optionally selecting an artboard by name.")
+            .def (
+                "load_bytes",
+                [] (RiveOffscreenRenderer& self, py::buffer buffer, std::optional<std::string> artboard)
+                {
+                    auto bytes = copyBuffer (std::move (buffer));
+                    auto result = self.loadFromBytes (
+                        Span<const uint8> (bytes.data(), bytes.size()),
+                        artboard ? String (*artboard) : String());
+                    handleResult (result);
+                },
+                "data"_a,
+                "artboard"_a = std::nullopt,
+                "Loads a .riv file from a bytes-like object.")
+            .def (
+                "list_artboards",
+                [] (const RiveOffscreenRenderer& self)
+                {
+                    return toStdVector (self.listArtboards());
+                },
+                "Returns the artboards available in the loaded file.")
+            .def (
+                "list_animations",
+                [] (const RiveOffscreenRenderer& self)
+                {
+                    return toStdVector (self.listAnimations());
+                },
+                "Returns animations defined on the active artboard.")
+            .def (
+                "list_state_machines",
+                [] (const RiveOffscreenRenderer& self)
+                {
+                    return toStdVector (self.listStateMachines());
+                },
+                "Returns state machines defined on the active artboard.")
+            .def (
+                "select_artboard",
+                [] (RiveOffscreenRenderer& self, const std::string& artboard)
+                {
+                    handleResult (self.selectArtboard (String (artboard)));
+                },
+                "artboard"_a,
+                "Selects an artboard by name.")
+            .def (
+                "get_active_artboard",
+                &RiveOffscreenRenderer::getActiveArtboardName,
+                "Returns the name of the current artboard, or an empty string if none is active.")
+            .def (
+                "play_animation",
+                [] (RiveOffscreenRenderer& self, const std::string& animation, bool shouldLoop)
+                {
+                    return self.playAnimation (String (animation), shouldLoop);
+                },
+                "animation"_a,
+                "loop"_a = true,
+                "Starts playing a linear animation and returns true on success.")
+            .def (
+                "play_state_machine",
+                [] (RiveOffscreenRenderer& self, const std::string& machine)
+                {
+                    return self.playStateMachine (String (machine));
+                },
+                "machine"_a,
+                "Starts playing a state machine and returns true on success.")
+            .def ("stop", &RiveOffscreenRenderer::stop, "Stops any running animation or state machine.")
+            .def (
+                "set_paused",
+                &RiveOffscreenRenderer::setPaused,
+                "paused"_a,
+                "Pauses or resumes advancement of the active scene.")
+            .def (
+                "is_paused",
+                &RiveOffscreenRenderer::isPaused,
+                "Returns true when the renderer is paused.")
+            .def (
+                "set_bool_input",
+                [] (RiveOffscreenRenderer& self, const std::string& name, bool value)
+                {
+                    return self.setBoolInput (String (name), value);
+                },
+                "name"_a,
+                "value"_a,
+                "Sets a boolean state-machine input and returns true if it existed.")
+            .def (
+                "set_number_input",
+                [] (RiveOffscreenRenderer& self, const std::string& name, double value)
+                {
+                    return self.setNumberInput (String (name), value);
+                },
+                "name"_a,
+                "value"_a,
+                "Sets a numeric state-machine input and returns true if it existed.")
+            .def (
+                "fire_trigger",
+                [] (RiveOffscreenRenderer& self, const std::string& name)
+                {
+                    return self.fireTriggerInput (String (name));
+                },
+                "name"_a,
+                "Fires a trigger state-machine input and returns true if it existed.")
+            .def (
+                "advance",
+                &RiveOffscreenRenderer::advance,
+                "delta_seconds"_a,
+                "Advances the current scene by the given time and renders a new frame.")
+            .def (
+                "get_width",
+                &RiveOffscreenRenderer::getWidth,
+                "Returns the width of the offscreen surface in pixels.")
+            .def (
+                "get_height",
+                &RiveOffscreenRenderer::getHeight,
+                "Returns the height of the offscreen surface in pixels.")
+            .def (
+                "get_row_stride",
+                &RiveOffscreenRenderer::getRowStride,
+                "Returns the stride in bytes between rows of the frame buffer.")
+            .def (
+                "get_frame_bytes",
+                [] (const RiveOffscreenRenderer& self)
+                {
+                    const auto& frame = self.getFrameBuffer();
+                    return py::bytes (reinterpret_cast<const char*> (frame.data()), static_cast<py::ssize_t> (frame.size()));
+                },
+                "Returns a copy of the most recent frame as bytes in BGRA order.")
+            .def (
+                "acquire_frame_view",
+                [] (const RiveOffscreenRenderer& self)
+                {
+                    return makeFrameMemoryView (self);
+                },
+                "Returns a read-only memoryview that references the renderer's BGRA frame without copying.")
+            .def (
+                "get_last_error",
+                &RiveOffscreenRenderer::getLastError,
+                "Returns the last error message reported by the renderer.");
+    }
+}
+
+PYBIND11_MODULE (yup_rive_renderer, module)
+{
+    namespace py = pybind11;
+    module.doc () =
+        "Bindings that expose yup::RiveOffscreenRenderer to Python callers."
+        " The module is designed for Windows 11 workflows using Direct3D11.";
+
+    python::bindRiveOffscreenRenderer (module);
+}
+
+} // namespace python
+} // namespace yup
+

--- a/python/tests/__init__.py
+++ b/python/tests/__init__.py
@@ -1,3 +1,6 @@
 from . import common
 
-import yup
+try:
+    import yup  # noqa: F401
+except ModuleNotFoundError:
+    yup = None

--- a/python/tests/common.py
+++ b/python/tests/common.py
@@ -4,8 +4,7 @@ import glob
 from pathlib import Path
 
 try:
-	import yup
-
+    import yup  # type: ignore  # noqa: F401
 except ImportError:
     folder = (Path(__file__).parent.parent / "build")
     for ext in ["*.so", "*.pyd"]:
@@ -15,4 +14,7 @@ except ImportError:
                 sys.path.append(str(Path(f).parent))
                 break
 
-    import yup
+    try:
+        import yup  # type: ignore  # noqa: F401
+    except ImportError:
+        yup = None

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -4,7 +4,10 @@ import pytest
 from . import common
 from .utilities import get_runtime_data_folder, remove_directory_recursively
 
-import yup
+try:
+    import yup  # type: ignore  # noqa: F401
+except ImportError:
+    yup = None
 
 #==================================================================================================
 
@@ -20,6 +23,9 @@ def pytest_unconfigure(config):
     if sys.gettrace() is not None:
         return
 
+    if yup is None:
+        return
+
     remove_directory_recursively(get_runtime_data_folder().getFullPathName(), [".gitignore"])
 
 #==================================================================================================
@@ -29,6 +35,9 @@ def yield_test():
 
 @pytest.fixture
 def juce_app():
+    if yup is None:
+        pytest.skip("yup native module is not available")
+
     class Application(yup.YUPApplication):
         def __init__(self):
             super().__init__()

--- a/python/tests/test_yup_ndi/test_orchestrator.py
+++ b/python/tests/test_yup_ndi/test_orchestrator.py
@@ -1,0 +1,347 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Mapping, Optional
+
+import pytest
+
+import yup_ndi.orchestrator as orchestrator_module
+from yup_ndi import NDIOrchestrator, NDIStreamConfig
+
+
+class FakeRenderer:
+    def __init__ (self, width: int, height: int, *, expose_view: bool = False) -> None:
+        self._width = width
+        self._height = height
+        self._row_stride = width * 4
+        self.loaded_file: Optional[str] = None
+        self.loaded_bytes: Optional[bytes] = None
+        self.loaded_artboard: Optional[str] = None
+        self.animations: list[tuple[str, bool]] = []
+        self.state_machines: list[str] = []
+        self.bool_inputs: Dict[str, bool] = {}
+        self.number_inputs: Dict[str, float] = {}
+        self.triggers: list[str] = []
+        self.selected_artboard: Optional[str] = None
+        self.advanced: list[float] = []
+        self.paused = False
+        self.stopped = False
+        self._frame_bytes = bytes(range(width * height * 4))
+        self._frame_array = bytearray(self._frame_bytes)
+        self._use_view = expose_view
+        self.view_requests = 0
+        self.byte_requests = 0
+
+    def is_valid (self) -> bool:
+        return True
+
+    def load_file (self, path: str, artboard: Optional[str]) -> None:
+        self.loaded_file = path
+        self.loaded_artboard = artboard
+
+    def load_bytes (self, data: bytes, artboard: Optional[str]) -> None:
+        self.loaded_bytes = bytes(data)
+        self.loaded_artboard = artboard
+
+    def play_animation (self, name: str, loop: bool = True) -> bool:
+        self.animations.append((name, loop))
+        return True
+
+    def play_state_machine (self, name: str) -> bool:
+        self.state_machines.append(name)
+        return True
+
+    def select_artboard (self, name: str) -> None:
+        self.selected_artboard = name
+
+    def set_paused (self, should_pause: bool) -> None:
+        self.paused = should_pause
+
+    def set_bool_input (self, name: str, value: bool) -> bool:
+        self.bool_inputs[name] = value
+        return True
+
+    def set_number_input (self, name: str, value: float) -> bool:
+        self.number_inputs[name] = value
+        return True
+
+    def fire_trigger (self, name: str) -> bool:
+        self.triggers.append(name)
+        return True
+
+    def advance (self, delta_seconds: float) -> bool:
+        self.advanced.append(delta_seconds)
+        return True
+
+    def get_frame_bytes (self) -> bytes:
+        self.byte_requests += 1
+        return self._frame_bytes
+
+    def acquire_frame_view (self) -> memoryview:
+        if not self._use_view:
+            raise AttributeError("acquire_frame_view not available")
+
+        self.view_requests += 1
+        return memoryview(self._frame_array).cast("B", shape=(self._height, self._width, 4))
+
+    def get_width (self) -> int:
+        return self._width
+
+    def get_height (self) -> int:
+        return self._height
+
+    def get_row_stride (self) -> int:
+        return self._row_stride
+
+    def stop (self) -> None:
+        self.stopped = True
+
+
+@dataclass
+class FakeSenderCall:
+    width: int
+    height: int
+    stride: int
+    timestamp: int
+    payload: bytes
+
+
+class FakeSenderHandle:
+    def __init__ (self, name: str) -> None:
+        self.name = name
+        self.calls: list[FakeSenderCall] = []
+        self.metadata: list[Mapping[str, Mapping[str, Any]]] = []
+        self.closed = False
+
+    def send (self, buffer: memoryview, width: int, height: int, stride: int, timestamp: int) -> None:
+        self.calls.append(FakeSenderCall(width, height, stride, timestamp, bytes(buffer)))
+
+    def apply_metadata (self, metadata: Mapping[str, Mapping[str, Any]]) -> None:
+        if metadata:
+            self.metadata.append(metadata)
+
+    def close (self) -> None:
+        self.closed = True
+
+
+class FakeFactories:
+    def __init__ (self) -> None:
+        self.renderers: Dict[str, FakeRenderer] = {}
+        self.senders: Dict[str, FakeSenderHandle] = {}
+
+    def renderer (self, config: NDIStreamConfig) -> FakeRenderer:
+        expose_view = bool(config.renderer_options.get("expose_view"))
+        renderer = FakeRenderer(config.width, config.height, expose_view=expose_view)
+        self.renderers[config.name] = renderer
+        return renderer
+
+    def sender (self, config: NDIStreamConfig, renderer: FakeRenderer) -> FakeSenderHandle:
+        handle = FakeSenderHandle(config.name)
+        self.senders[config.name] = handle
+        return handle
+
+
+def test_orchestrator_advances_and_sends_frames () -> None:
+    factories = FakeFactories()
+    orchestrator = NDIOrchestrator(
+        renderer_factory=factories.renderer,
+        sender_factory=factories.sender,
+        timestamp_mapper=lambda seconds: int(seconds * 1_000),
+        time_provider=lambda: 1.25,
+    )
+
+    config = NDIStreamConfig(
+        name="main",
+        width=2,
+        height=2,
+        riv_bytes=b"riv data",
+        animation="run",
+        loop_animation=False,
+        metadata={"ndi": {"note": "demo"}},
+    )
+
+    orchestrator.add_stream(config)
+
+    renderer = factories.renderers["main"]
+    assert renderer.loaded_bytes == b"riv data"
+    assert renderer.animations == [("run", False)]
+
+    progressed = orchestrator.advance_stream("main", 0.5)
+    assert progressed is True
+    assert renderer.advanced == [0.5]
+
+    sender = factories.senders["main"]
+    assert sender.calls, "Sender should have emitted a frame"
+
+
+def test_orchestrator_prefers_acquire_frame_view () -> None:
+    factories = FakeFactories()
+    orchestrator = NDIOrchestrator(
+        renderer_factory=factories.renderer,
+        sender_factory=factories.sender,
+        timestamp_mapper=lambda seconds: int(seconds * 1_000),
+        time_provider=lambda: 0.0,
+    )
+
+    config = NDIStreamConfig(
+        name="view", width=2, height=2, riv_bytes=b"data", renderer_options={"expose_view": True}
+    )
+
+    orchestrator.add_stream(config)
+
+    renderer = factories.renderers["view"]
+    sender = factories.senders["view"]
+
+    orchestrator.advance_stream("view", 0.25)
+
+    assert renderer.view_requests == 1
+    assert renderer.byte_requests == 0, "acquire_frame_view should prevent fallback to get_frame_bytes"
+    payload = sender.calls[0].payload
+    assert payload == bytes(range(16))
+
+
+def test_orchestrator_remove_stream_closes_resources () -> None:
+    factories = FakeFactories()
+    orchestrator = NDIOrchestrator(
+        renderer_factory=factories.renderer,
+        sender_factory=factories.sender,
+        timestamp_mapper=lambda seconds: int(seconds * 1_000),
+        time_provider=lambda: 0.0,
+    )
+
+    config = NDIStreamConfig(name="cleanup", width=2, height=2, riv_bytes=b"riv data")
+
+    orchestrator.add_stream(config)
+    orchestrator.remove_stream("cleanup")
+
+    renderer = factories.renderers["cleanup"]
+    sender = factories.senders["cleanup"]
+
+    assert renderer.stopped is True
+    assert sender.closed is True
+
+
+def test_default_renderer_factory_calls_binding (monkeypatch: pytest.MonkeyPatch) -> None:
+    created_dimensions: list[tuple[int, int]] = []
+
+    class DummyRenderer:
+        valid = True
+
+        def __init__ (self, width: int, height: int) -> None:
+            created_dimensions.append((width, height))
+
+        def is_valid (self) -> bool:
+            return type(self).valid
+
+    monkeypatch.setattr(orchestrator_module, "RiveOffscreenRenderer", DummyRenderer)
+
+    config = NDIStreamConfig(name="binding", width=1920, height=1080, riv_bytes=b"riv")
+    renderer = orchestrator_module._default_renderer_factory(config)
+
+    assert isinstance(renderer, DummyRenderer)
+    assert created_dimensions == [(1920, 1080)]
+
+    DummyRenderer.valid = False
+    with pytest.raises(RuntimeError):
+        orchestrator_module._default_renderer_factory(config)
+
+
+def test_remove_stream_closes_sender () -> None:
+    factories = FakeFactories()
+    orchestrator = NDIOrchestrator(
+        renderer_factory=factories.renderer,
+        sender_factory=factories.sender,
+        timestamp_mapper=lambda seconds: int(seconds * 1_000),
+        time_provider=lambda: 0.0,
+    )
+
+    config = NDIStreamConfig(name="solo", width=1, height=1, riv_bytes=b"riv")
+    orchestrator.add_stream(config)
+    orchestrator.advance_all(0.0)
+
+    orchestrator.remove_stream("solo")
+    assert factories.senders["solo"].closed is True
+    assert factories.renderers["solo"].stopped is True
+
+
+def test_apply_stream_control_handles_common_actions () -> None:
+    factories = FakeFactories()
+    orchestrator = NDIOrchestrator(
+        renderer_factory=factories.renderer,
+        sender_factory=factories.sender,
+        timestamp_mapper=lambda seconds: 0,
+        time_provider=lambda: 0.0,
+    )
+
+    config = NDIStreamConfig(name="control", width=4, height=4, riv_bytes=b"riv")
+    orchestrator.add_stream(config)
+
+    renderer = factories.renderers["control"]
+
+    orchestrator.apply_stream_control("control", "pause")
+    assert renderer.paused is True
+    orchestrator.apply_stream_control("control", "resume")
+    assert renderer.paused is False
+
+    orchestrator.apply_stream_control("control", "play_animation", {"name": "idle", "loop": True})
+    orchestrator.apply_stream_control("control", "play_state_machine", {"name": "fsm"})
+    orchestrator.apply_stream_control("control", "select_artboard", {"name": "Alt"})
+
+    orchestrator.apply_stream_control("control", "set_input", {"name": "armed", "value": True})
+    orchestrator.apply_stream_control("control", "set_input", {"name": "intensity", "value": 0.75})
+    orchestrator.apply_stream_control("control", "set_input", {"name": "trigger", "value": "trigger"})
+    orchestrator.apply_stream_control("control", "stop")
+
+    assert renderer.animations[-1] == ("idle", True)
+    assert renderer.state_machines[-1] == "fsm"
+    assert renderer.selected_artboard == "Alt"
+    assert renderer.bool_inputs["armed"] is True
+    assert renderer.number_inputs["intensity"] == pytest.approx(0.75)
+    assert renderer.triggers == ["trigger"]
+    assert renderer.stopped is True
+
+    with pytest.raises(ValueError):
+        orchestrator.apply_stream_control("control", "unknown")
+
+
+def test_dispatch_control_invokes_registered_handler () -> None:
+    factories = FakeFactories()
+    orchestrator = NDIOrchestrator(
+        renderer_factory=factories.renderer,
+        sender_factory=factories.sender,
+        timestamp_mapper=lambda seconds: 0,
+        time_provider=lambda: 0.0,
+    )
+
+    orchestrator.add_stream(NDIStreamConfig(name="a", width=1, height=1, riv_bytes=b"riv"))
+    orchestrator.add_stream(NDIStreamConfig(name="b", width=1, height=1, riv_bytes=b"riv"))
+
+    dispatched: list[tuple[str, Mapping[str, Any]]] = []
+
+    def handler (orc: NDIOrchestrator, command: str, payload: Mapping[str, Any]) -> str:
+        dispatched.append((command, payload))
+        for stream_name in orc.list_streams():
+            orc.apply_stream_control(stream_name, payload["action"], payload.get("parameters", {}))
+        return "ok"
+
+    orchestrator.register_control_handler("toggle", handler)
+    result = orchestrator.dispatch_control("toggle", {"action": "pause"})
+
+    assert result == "ok"
+    assert dispatched == [("toggle", {"action": "pause"})]
+    assert all(factories.renderers[name].paused for name in ("a", "b"))
+
+    orchestrator.unregister_control_handler("toggle")
+    with pytest.raises(KeyError):
+        orchestrator.dispatch_control("toggle")
+
+
+def test_invalid_configuration_rejected () -> None:
+    with pytest.raises(ValueError):
+        NDIStreamConfig(name="bad", width=0, height=10, riv_bytes=b"riv")
+
+    with pytest.raises(ValueError):
+        NDIStreamConfig(name="bad", width=1, height=1)
+
+    with pytest.raises(TypeError):
+        NDIStreamConfig(name="bad", width=1, height=1, riv_bytes=b"riv", frame_rate="fast")  # type: ignore[arg-type]

--- a/python/tests/test_yup_rive_renderer/__init__.py
+++ b/python/tests/test_yup_rive_renderer/__init__.py
@@ -1,0 +1,1 @@
+"""Test package for yup_rive_renderer bindings."""

--- a/python/tests/test_yup_rive_renderer/test_binding_interface.py
+++ b/python/tests/test_yup_rive_renderer/test_binding_interface.py
@@ -1,0 +1,34 @@
+"""Smoke tests for the yup_rive_renderer pybind11 module."""
+from __future__ import annotations
+
+import pytest
+
+binding = pytest.importorskip(
+    "yup_rive_renderer", reason="yup_rive_renderer extension module is not available"
+)
+
+
+@pytest.mark.parametrize("width,height", [(16, 16), (1, 1)])
+def test_renderer_construction_exposes_expected_accessors (width: int, height: int) -> None:
+    renderer = binding.RiveOffscreenRenderer(width, height)
+
+    assert hasattr(renderer, "is_valid")
+    assert hasattr(renderer, "get_frame_bytes")
+    assert hasattr(renderer, "acquire_frame_view")
+    assert renderer.get_width() == width
+    assert renderer.get_height() == height
+    assert renderer.get_row_stride() >= width * 4
+
+
+def test_renderer_acquire_frame_view_returns_memoryview () -> None:
+    renderer = binding.RiveOffscreenRenderer(8, 8)
+
+    if not renderer.is_valid():
+        pytest.skip("Renderer could not initialise in this environment")
+
+    view = renderer.acquire_frame_view()
+    assert isinstance(view, memoryview)
+    assert view.format == "B"
+
+    frame_bytes = renderer.get_frame_bytes()
+    assert isinstance(frame_bytes, (bytes, bytearray))

--- a/python/tests/utilities.py
+++ b/python/tests/utilities.py
@@ -1,9 +1,14 @@
+from __future__ import annotations
+
 import os
 from pathlib import Path
 
 from . import common
 
-import yup
+try:
+    import yup  # type: ignore  # noqa: F401
+except ImportError:
+    yup = None
 
 #==================================================================================================
 

--- a/python/yup_ndi/__init__.py
+++ b/python/yup_ndi/__init__.py
@@ -1,0 +1,30 @@
+"""NDI orchestration helpers for YUP's Rive renderer bindings.
+
+This package is tailored for Windows 11 automation hosts that drive the
+Direct3D 11 offscreen renderer exposed via :mod:`yup_rive_renderer` and forward
+frames to the official `cyndilib` Python bindings for NDI®. The modules here
+focus on:
+
+* Managing multiple concurrent renderer instances and mapping their BGRA frame
+  buffers into NDI senders without unnecessary copies.
+* Translating renderer timing into the 100 ns timestamp domain that the NDI SDK
+  expects, ensuring downstream receivers observe stable clocks.
+* Providing optional control hooks so higher level REST or OSC layers can route
+  play/pause/scene changes while keeping rendering and transport logic in one
+  place.
+
+Runtime expectations:
+
+* The host must run Windows 11 with the Microsoft Visual Studio 2022 toolchain
+  and GPU drivers capable of Direct3D 11 offscreen rendering.
+* The :mod:`cyndilib` package (>=0.0.8) must be installed to publish NDI video.
+* The :mod:`yup_rive_renderer` extension must be built from this repository with
+  `YUP_ENABLE_AUDIO_MODULES=OFF` as documented in ``docs/rive_ndi_overview.md``.
+
+The top-level API re-exports :class:`~yup_ndi.orchestrator.NDIOrchestrator` and
+:class:`~yup_ndi.orchestrator.NDIStreamConfig` for convenience.
+"""
+
+from .orchestrator import NDIOrchestrator, NDIStreamConfig
+
+__all__ = ["NDIOrchestrator", "NDIStreamConfig"]

--- a/python/yup_ndi/orchestrator.py
+++ b/python/yup_ndi/orchestrator.py
@@ -1,0 +1,386 @@
+"""Utilities for publishing Rive frames over NDI."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from fractions import Fraction
+import logging
+import time
+from typing import Any, Callable, Dict, List, Mapping, MutableMapping, Optional, Protocol
+
+try:  # pragma: no cover - optional dependency handled lazily
+    import cyndilib
+except ImportError:  # pragma: no cover - exercised in tests via dependency injection
+    cyndilib = None  # type: ignore
+
+try:  # pragma: no cover - optional during unit tests
+    from yup_rive_renderer import RiveOffscreenRenderer
+except ImportError:  # pragma: no cover - exercised in tests via dependency injection
+    RiveOffscreenRenderer = None  # type: ignore
+
+
+_logger = logging.getLogger(__name__)
+
+
+TimestampMapper = Callable[[float], int]
+TimeProvider = Callable[[], float]
+
+
+class SenderHandle(Protocol):
+    """Protocol implemented by sender adapters used by :class:`NDIOrchestrator`."""
+
+    def send (self, buffer: memoryview, width: int, height: int, stride: int, timestamp: int) -> None: ...
+
+    def apply_metadata (self, metadata: Mapping[str, Mapping[str, Any]]) -> None: ...
+
+    def close (self) -> None: ...
+
+
+class RendererFactory(Protocol):
+    """Factory protocol used to instantiate renderers for each stream."""
+
+    def __call__ (self, config: "NDIStreamConfig") -> Any: ...
+
+
+class SenderFactory(Protocol):
+    """Factory protocol used to create sender handles for each stream."""
+
+    def __call__ (self, config: "NDIStreamConfig", renderer: Any) -> SenderHandle: ...
+
+
+ControlHandler = Callable[["NDIOrchestrator", str, Mapping[str, Any]], Any]
+
+
+@dataclass(slots=True)
+class NDIStreamConfig:
+    """Configuration payload for registering a renderer/NDI publishing pipeline."""
+
+    name: str
+    width: int
+    height: int
+    riv_path: Optional[str] = None
+    riv_bytes: Optional[bytes] = None
+    artboard: Optional[str] = None
+    animation: Optional[str] = None
+    state_machine: Optional[str] = None
+    loop_animation: bool = True
+    frame_rate: Optional[Fraction | float | tuple[int, int]] = None
+    ndi_groups: str = ""
+    clock_video: bool = True
+    clock_audio: bool = False
+    sender_options: MutableMapping[str, Any] = field(default_factory=dict)
+    renderer_options: MutableMapping[str, Any] = field(default_factory=dict)
+    metadata: MutableMapping[str, Mapping[str, Any]] = field(default_factory=dict)
+    use_async_send: bool = True
+
+    def __post_init__ (self) -> None:
+        if not self.riv_path and self.riv_bytes is None:
+            raise ValueError("Either 'riv_path' or 'riv_bytes' must be provided")
+
+        if self.riv_path and self.riv_bytes is not None:
+            _logger.debug("Stream %s supplied both riv_path and riv_bytes; riv_path will be used", self.name)
+            self.riv_bytes = None
+
+        if self.width <= 0 or self.height <= 0:
+            raise ValueError("Renderer dimensions must be positive")
+
+        if isinstance(self.frame_rate, tuple):
+            self.frame_rate = Fraction(self.frame_rate[0], self.frame_rate[1])
+        elif isinstance(self.frame_rate, float):
+            self.frame_rate = Fraction(self.frame_rate).limit_denominator()
+        elif self.frame_rate is not None and not isinstance(self.frame_rate, Fraction):
+            raise TypeError("frame_rate must be a Fraction, float, tuple, or None")
+
+
+class _NDIStream:
+    """Internal book-keeping for a single renderer + sender pair."""
+
+    def __init__ (
+        self,
+        config: NDIStreamConfig,
+        renderer: Any,
+        sender_handle: SenderHandle,
+        timestamp_mapper: TimestampMapper,
+        time_provider: TimeProvider,
+    ) -> None:
+        self.config = config
+        self.renderer = renderer
+        self.sender_handle = sender_handle
+        self._timestamp_mapper = timestamp_mapper
+        self._time_provider = time_provider
+
+    def advance_and_send (self, delta_seconds: float, timestamp: Optional[float]) -> bool:
+        now = timestamp if timestamp is not None else self._time_provider()
+        ndi_timestamp = self._timestamp_mapper(now)
+
+        progressed = bool(self.renderer.advance(float(delta_seconds)))
+        buffer = self._acquire_frame_buffer()
+        self.sender_handle.send(buffer, self.renderer.get_width(), self.renderer.get_height(), self.renderer.get_row_stride(), ndi_timestamp)
+
+        return progressed
+
+    def _acquire_frame_buffer (self) -> memoryview:
+        view_getter = getattr(self.renderer, "acquire_frame_view", None)
+
+        if callable(view_getter):
+            try:
+                view = view_getter()
+                flattened = memoryview(view).cast("B")
+                return flattened
+            except (TypeError, ValueError):
+                _logger.debug("Falling back to get_frame_bytes for stream %s", self.config.name)
+            except Exception:  # pragma: no cover - diagnostic only
+                _logger.exception("acquire_frame_view failed; falling back to get_frame_bytes")
+
+        frame_bytes = self.renderer.get_frame_bytes()
+        if isinstance(frame_bytes, memoryview):
+            return frame_bytes.cast("B")
+        if isinstance(frame_bytes, (bytes, bytearray)):  # zero-copy read-only in CPython
+            return memoryview(frame_bytes)
+
+        return memoryview(bytes(frame_bytes))
+
+    def apply_control (self, action: str, parameters: Mapping[str, Any]) -> Any:
+        action = action.lower()
+        if action == "pause":
+            self.renderer.set_paused(True)
+            return True
+        if action == "resume":
+            self.renderer.set_paused(False)
+            return True
+        if action == "play_animation":
+            name = parameters.get("name")
+            if not name:
+                raise ValueError("play_animation requires a 'name' parameter")
+            loop = bool(parameters.get("loop", True))
+            return self.renderer.play_animation(name, loop)
+        if action == "play_state_machine":
+            name = parameters.get("name")
+            if not name:
+                raise ValueError("play_state_machine requires a 'name' parameter")
+            return self.renderer.play_state_machine(name)
+        if action == "stop":
+            self.renderer.stop()
+            return True
+        if action == "select_artboard":
+            name = parameters.get("name")
+            if not name:
+                raise ValueError("select_artboard requires a 'name' parameter")
+            self.renderer.select_artboard(name)
+            return True
+        if action == "set_input":
+            input_name = parameters.get("name")
+            if not input_name:
+                raise ValueError("set_input requires a 'name' parameter")
+            value = parameters.get("value")
+            if isinstance(value, bool):
+                return self.renderer.set_bool_input(input_name, value)
+            if isinstance(value, (int, float)):
+                return self.renderer.set_number_input(input_name, float(value))
+            if value == "trigger":
+                return self.renderer.fire_trigger(input_name)
+            raise ValueError("Unsupported input value type")
+
+        raise ValueError(f"Unknown control action: {action}")
+
+    def close (self) -> None:
+        try:
+            self.sender_handle.close()
+        finally:
+            stop = getattr(self.renderer, "stop", None)
+            if callable(stop):
+                stop()
+
+
+def _default_timestamp_mapper (seconds: float) -> int:
+    return int(seconds * 10_000_000)
+
+
+def _default_time_provider () -> float:
+    return time.perf_counter()
+
+
+def _default_renderer_factory (config: NDIStreamConfig) -> Any:
+    if RiveOffscreenRenderer is None:  # pragma: no cover - executed only in production without injection
+        raise ImportError("yup_rive_renderer is not available; build the extension before creating streams")
+
+    if config.renderer_options:
+        _logger.warning("Renderer options are ignored by the default factory")
+
+    renderer = RiveOffscreenRenderer(config.width, config.height)
+    if not renderer.is_valid():
+        raise RuntimeError("Failed to initialise RiveOffscreenRenderer")
+
+    return renderer
+
+
+class _CyndiLibSenderHandle:
+    """Concrete :class:`SenderHandle` that wraps :mod:`cyndilib` senders."""
+
+    def __init__ (self, sender: Any, video_frame: Any, use_async: bool) -> None:
+        self._sender = sender
+        self._video_frame = video_frame
+        self._use_async = use_async
+
+    def send (self, buffer: memoryview, width: int, height: int, stride: int, timestamp: int) -> None:
+        try:
+            self._video_frame.set_resolution(width, height)
+        except Exception:  # pragma: no cover - defensive, API documented as safe
+            pass
+
+        try:
+            setter = getattr(self._video_frame, "_set_line_stride", None)
+            if callable(setter):
+                setter(stride)
+        except Exception:  # pragma: no cover - defensive
+            _logger.debug("Failed to apply explicit line stride; continuing")
+
+        try:
+            if hasattr(self._video_frame, "ptr") and hasattr(self._video_frame.ptr, "timestamp"):
+                self._video_frame.ptr.timestamp = timestamp
+        except Exception:  # pragma: no cover - best effort only
+            _logger.debug("Unable to set NDI timestamp on video frame")
+
+        contiguous = buffer.cast("B")
+        self._sender.write_video(contiguous)
+        if self._use_async:
+            self._sender.send_video_async()
+        else:
+            self._sender.send_video()
+
+    def apply_metadata (self, metadata: Mapping[str, Mapping[str, Any]]) -> None:
+        if not metadata:
+            return
+
+        if not hasattr(self._sender, "send_metadata"):
+            _logger.warning("Sender implementation does not expose send_metadata")
+            return
+
+        for tag, attrs in metadata.items():
+            try:
+                self._sender.send_metadata(tag, dict(attrs))
+            except Exception:  # pragma: no cover - metadata transmission is best-effort
+                _logger.exception("Failed to send metadata '%s'", tag)
+
+    def close (self) -> None:
+        try:
+            self._sender.close()
+        except Exception:  # pragma: no cover - finalisation should not raise
+            _logger.debug("NDI sender close failed", exc_info=True)
+
+
+def _default_sender_factory (config: NDIStreamConfig, renderer: Any) -> SenderHandle:
+    if cyndilib is None:  # pragma: no cover - executed only in production without injection
+        raise ImportError("cyndilib is not installed; install cyndilib>=0.0.8 to stream over NDI")
+
+    sender_kwargs = dict(config.sender_options)
+    sender_kwargs.setdefault("clock_video", config.clock_video)
+    sender_kwargs.setdefault("clock_audio", config.clock_audio)
+
+    sender = cyndilib.Sender(config.name, ndi_groups=config.ndi_groups, **sender_kwargs)
+
+    video_frame = cyndilib.VideoSendFrame()
+    video_frame.set_fourcc(cyndilib.FourCC.BGRA)
+    video_frame.set_resolution(renderer.get_width(), renderer.get_height())
+
+    if config.frame_rate is not None:
+        video_frame.set_frame_rate(config.frame_rate)
+
+    sender.set_video_frame(video_frame)
+    sender.open()
+
+    return _CyndiLibSenderHandle(sender, video_frame, config.use_async_send)
+
+
+class NDIOrchestrator:
+    """Coordinates Rive renderer instances and NDI senders."""
+
+    def __init__ (
+        self,
+        renderer_factory: Optional[RendererFactory] = None,
+        sender_factory: Optional[SenderFactory] = None,
+        timestamp_mapper: TimestampMapper = _default_timestamp_mapper,
+        time_provider: TimeProvider = _default_time_provider,
+    ) -> None:
+        self._renderer_factory = renderer_factory or _default_renderer_factory
+        self._sender_factory = sender_factory or _default_sender_factory
+        self._timestamp_mapper = timestamp_mapper
+        self._time_provider = time_provider
+        self._streams: Dict[str, _NDIStream] = {}
+        self._control_handlers: Dict[str, ControlHandler] = {}
+
+    def __enter__ (self) -> "NDIOrchestrator":
+        return self
+
+    def __exit__ (self, exc_type, exc, tb) -> None:
+        self.close()
+
+    def add_stream (self, config: NDIStreamConfig) -> None:
+        if config.name in self._streams:
+            raise ValueError(f"A stream named '{config.name}' already exists")
+
+        renderer = self._renderer_factory(config)
+        self._initialise_renderer(renderer, config)
+
+        sender_handle = self._sender_factory(config, renderer)
+        stream = _NDIStream(config, renderer, sender_handle, self._timestamp_mapper, self._time_provider)
+        self._streams[config.name] = stream
+
+        sender_handle.apply_metadata(config.metadata)
+
+    def remove_stream (self, name: str) -> None:
+        stream = self._streams.pop(name)
+        stream.close()
+
+    def list_streams (self) -> List[str]:
+        return list(self._streams.keys())
+
+    def advance_stream (self, name: str, delta_seconds: float, timestamp: Optional[float] = None) -> bool:
+        stream = self._streams[name]
+        return stream.advance_and_send(delta_seconds, timestamp)
+
+    def advance_all (self, delta_seconds: float, timestamp: Optional[float] = None) -> Dict[str, bool]:
+        results: Dict[str, bool] = {}
+        for name, stream in list(self._streams.items()):
+            results[name] = stream.advance_and_send(delta_seconds, timestamp)
+        return results
+
+    def apply_stream_control (self, name: str, action: str, parameters: Optional[Mapping[str, Any]] = None) -> Any:
+        stream = self._streams[name]
+        return stream.apply_control(action, parameters or {})
+
+    def register_control_handler (self, command: str, handler: ControlHandler) -> None:
+        self._control_handlers[command] = handler
+
+    def unregister_control_handler (self, command: str) -> None:
+        self._control_handlers.pop(command, None)
+
+    def dispatch_control (self, command: str, payload: Optional[Mapping[str, Any]] = None) -> Any:
+        handler = self._control_handlers.get(command)
+        if handler is None:
+            raise KeyError(f"No handler registered for '{command}'")
+        return handler(self, command, payload or {})
+
+    def close (self) -> None:
+        for name in list(self._streams.keys()):
+            self.remove_stream(name)
+
+    def _initialise_renderer (self, renderer: Any, config: NDIStreamConfig) -> None:
+        if config.riv_path:
+            renderer.load_file(config.riv_path, config.artboard)
+        elif config.riv_bytes is not None:
+            renderer.load_bytes(config.riv_bytes, config.artboard)
+        else:  # pragma: no cover - guarded earlier but defensive
+            raise ValueError("Stream config missing riv_path/riv_bytes")
+
+        if config.animation:
+            ok = renderer.play_animation(config.animation, config.loop_animation)
+            if not ok:
+                raise RuntimeError(f"Failed to start animation '{config.animation}'")
+
+        if config.state_machine:
+            ok = renderer.play_state_machine(config.state_machine)
+            if not ok:
+                raise RuntimeError(f"Failed to start state machine '{config.state_machine}'")
+
+        if hasattr(renderer, "set_paused"):
+            renderer.set_paused(False)

--- a/tests/yup_gui/yup_RiveOffscreenRenderer.cpp
+++ b/tests/yup_gui/yup_RiveOffscreenRenderer.cpp
@@ -1,0 +1,98 @@
+/*
+  ==============================================================================
+
+   This file is part of the YUP library.
+   Copyright (c) 2025 - kunitoki@gmail.com
+
+   YUP is an open source library subject to open-source licensing.
+
+   The code included in this file is provided under the terms of the ISC license
+   http://www.isc.org/downloads/software-support-policy/isc-license. Permission
+   to use, copy, modify, and/or distribute this software for any purpose with or
+   without fee is hereby granted provided that the above copyright notice and
+   this permission notice appear in all copies.
+
+   YUP IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
+   EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
+   DISCLAIMED.
+
+  ==============================================================================
+*/
+
+#include <yup_gui/yup_gui.h>
+
+#include <cstddef>
+
+#include <gtest/gtest.h>
+
+using namespace yup;
+
+namespace
+{
+constexpr int kWidth = 64;
+constexpr int kHeight = 32;
+constexpr std::size_t kExpectedStride = static_cast<std::size_t> (kWidth) * 4u;
+constexpr std::size_t kExpectedBufferSize = static_cast<std::size_t> (kWidth) * static_cast<std::size_t> (kHeight) * 4u;
+} // namespace
+
+TEST (RiveOffscreenRendererTest, ReportsDimensionsAndFrameLayout)
+{
+    RiveOffscreenRenderer renderer (kWidth, kHeight);
+
+    EXPECT_EQ (kWidth, renderer.getWidth());
+    EXPECT_EQ (kHeight, renderer.getHeight());
+    EXPECT_EQ (kExpectedStride, renderer.getRowStride());
+
+    const auto& frameBuffer = renderer.getFrameBuffer();
+    EXPECT_EQ (kExpectedBufferSize, frameBuffer.size());
+
+    auto sharedBuffer = renderer.getFrameBufferShared();
+    ASSERT_TRUE (sharedBuffer);
+    EXPECT_EQ (kExpectedBufferSize, sharedBuffer->size());
+    EXPECT_EQ (sharedBuffer.get(), &frameBuffer);
+}
+
+TEST (RiveOffscreenRendererTest, SharedBufferReflectsLatestFrame)
+{
+    RiveOffscreenRenderer renderer (kWidth, kHeight);
+
+    auto firstView = renderer.getFrameBufferShared();
+    ASSERT_TRUE (firstView);
+
+    const auto* initialData = firstView->data();
+
+    const auto& frameBuffer = renderer.getFrameBuffer();
+    EXPECT_EQ (initialData, frameBuffer.data());
+
+    auto secondView = renderer.getFrameBufferShared();
+    EXPECT_EQ (initialData, secondView->data());
+    EXPECT_EQ (firstView.get(), secondView.get());
+}
+
+TEST (RiveOffscreenRendererTest, PauseStateCanBeToggled)
+{
+    RiveOffscreenRenderer renderer (kWidth, kHeight);
+
+    EXPECT_FALSE (renderer.isPaused());
+
+    renderer.setPaused (true);
+    EXPECT_TRUE (renderer.isPaused());
+
+    renderer.stop();
+    EXPECT_FALSE (renderer.isPaused());
+}
+
+TEST (RiveOffscreenRendererTest, ArtboardEnumerationIsStubbed)
+{
+    RiveOffscreenRenderer renderer (kWidth, kHeight);
+
+    EXPECT_TRUE (renderer.listArtboards().isEmpty());
+    EXPECT_TRUE (renderer.listAnimations().isEmpty());
+    EXPECT_TRUE (renderer.listStateMachines().isEmpty());
+    EXPECT_TRUE (renderer.getActiveArtboardName().isEmpty());
+
+    const auto result = renderer.selectArtboard ("Example");
+    EXPECT_TRUE (result.failed());
+    EXPECT_FALSE (renderer.getLastError().isEmpty());
+}
+


### PR DESCRIPTION
## Summary
- add focused pytest coverage that exercises the orchestrator’s memoryview handling, renderer shutdown, and default binding factory wiring
- introduce binding smoke tests that validate yup_rive_renderer construction and zero-copy frame access when the extension is available
- document the Windows build + packaging workflow and surface a just recipe for running the renderer/NDI smoke suites

## Testing
- pytest python/tests/test_yup_ndi/test_orchestrator.py -q
- pytest python/tests/test_yup_rive_renderer/test_binding_interface.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d2da4e335c83299bdb54f55e91f78b