### PR TITLE
Improve Rive asset loading and control plumbing

### DIFF
--- a/modules/yup_gui/artboard/yup_ArtboardFile.h
+++ b/modules/yup_gui/artboard/yup_ArtboardFile.h
@@ -19,6 +19,12 @@
   ==============================================================================
 */
 
+namespace rive
+{
+class Factory;
+class FileAsset;
+} // namespace rive
+
 namespace yup
 {
 
@@ -46,7 +52,7 @@ public:
     //==============================================================================
     /** The result of loading a Rive file. */
     using LoadResult = ResultValue<std::shared_ptr<ArtboardFile>>;
-    using AssetLoadCallback = std::function<bool (const AssetInfo&, Span<const uint8>, rive::Factory& factory)>;
+    using AssetLoadCallback = std::function<bool (const AssetInfo&, rive::FileAsset&, Span<const uint8>, rive::Factory& factory)>;
 
     /** Loads a Rive file from a file.
 


### PR DESCRIPTION
## Summary
- add a default asset loader for ArtboardFile so .riv imports can resolve in-band and sidecar assets
- expose configurable state machine inputs and fix trigger control plumbing in the NDI orchestrator
- extend orchestrator unit tests to cover the new input paths and error handling

## Testing
- pytest python/tests/test_yup_ndi


------
https://chatgpt.com/codex/tasks/task_e_68d319b0651c83298007445bb8151028