### PR TITLE
Add Windows build guide, packaging automation, and integration tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,6 +109,9 @@ Primary module headers (e.g., `yup_graphics.h`) must also include the declaratio
 2. **Integration testing:** Add or extend combined tests that exercise the renderer bindings feeding the NDI orchestrator (mocked senders acceptable in CI).
 3. **Performance validation:** Profile renderer → Python throughput to ensure zero-copy semantics on Windows hardware.
 
+# Packaging
+- Run `python tools/package_wheel.py` to produce a release-mode build and wheel.
+
 ## Workflow Expectations
 - Analyse existing helpers (e.g., `modules/yup_graphics/`, `modules/yup_core/`) before introducing new abstractions; reuse utilities wherever feasible.
 - Keep build flags, documentation, and scripts aligned with Windows 11 + MSVC 2022 assumptions. Non-Windows builds may remain stubbed but must compile.

--- a/docs/BUILD_WINDOWS.md
+++ b/docs/BUILD_WINDOWS.md
@@ -1,0 +1,116 @@
+# Windows Build Guide
+
+This guide walks through building the YUP renderer, running its test suite, and producing the Python extension on a **fresh Windows 11 installation**. The steps below assume you are starting from an empty machine and want a repeatable process that any contributor can follow.
+
+## 1. Install Required Software
+
+1. **Visual Studio 2022**
+   - Download the [Visual Studio installer](https://visualstudio.microsoft.com/downloads/).
+   - Install the *Desktop development with C++* workload.
+   - Within the workload, ensure the following optional components are selected:
+     - MSVC v143 build tools for x86 and x64
+     - Windows 10 SDK (10.0.19041 or newer) or Windows 11 SDK
+     - C++ CMake tools for Windows
+     - C++ ATL for latest v143 build tools (optional but recommended)
+2. **CMake 3.28 or newer**
+   - Visual Studio bundles an older version. Install the latest release from [cmake.org/download](https://cmake.org/download/), and choose the option to add CMake to the system PATH for all users.
+3. **Python 3.11 (or newer 3.10+)**
+   - Install from [python.org](https://www.python.org/downloads/windows/), making sure to check the option to *Add python.exe to PATH*.
+   - After installation, verify the interpreter with `python --version`.
+4. *(Optional but recommended)* **Git for Windows**
+   - Install from [git-scm.com](https://git-scm.com/download/win) to access Git Bash and command-line tooling.
+
+## 2. Clone the Repository
+
+Open a *x64 Native Tools Command Prompt for VS 2022* (search from the Start menu) to ensure MSVC and the Windows SDK are on the PATH.
+
+```bat
+cd %USERPROFILE%\source\repos
+git clone --recurse-submodules https://github.com/kunitoki/yup.git
+cd yup
+```
+
+If you already cloned the repository without submodules, run:
+
+```bat
+git submodule update --init --recursive
+```
+
+## 3. Configure the Build with CMake
+
+Create a dedicated build directory to keep generated files separate from the source tree. The generator below targets Visual Studio 17 2022 and configures the entire project, including the renderer, tests, and Python module.
+
+```bat
+cmake -S . -B build\msvc-release ^
+  -G "Visual Studio 17 2022" ^
+  -A x64 ^
+  -DCMAKE_BUILD_TYPE=Release ^
+  -DYUP_BUILD_TESTS=ON ^
+  -DYUP_BUILD_EXAMPLES=OFF
+```
+
+- `-S` and `-B` select the source and build folders.
+- `-G` and `-A` ensure we target the 64-bit MSVC toolchain.
+- `-DYUP_BUILD_TESTS=ON` enables GoogleTest targets.
+- `-DYUP_BUILD_EXAMPLES=OFF` speeds up compilation when you only need the renderer pipeline.
+
+## 4. Build All Targets
+
+Compile the solution in **Release** mode, including the renderer library, pybind11 module, and tests.
+
+```bat
+cmake --build build\msvc-release --config Release
+```
+
+The command produces:
+- `yup_rive_renderer.pyd` – the Python extension module.
+- All static and dynamic libraries for the renderer core.
+- Unit test executables located under `build\msvc-release\tests\Release`.
+
+## 5. Run the Test Suite (Optional but Recommended)
+
+From the same Developer Command Prompt, execute the compiled tests via CTest:
+
+```bat
+ctest --test-dir build\msvc-release --config Release
+```
+
+To exercise the Python tests (requires the `.pyd` extension on the Python path):
+
+```bat
+set PYTHONPATH=%CD%\build\msvc-release\python\Release
+python -m pytest python\tests -vv
+```
+
+## 6. Locate the Python Extension
+
+After a successful build, the compiled module is located at:
+
+```
+build\msvc-release\python\Release\yup_rive_renderer.pyd
+```
+
+Copy this file into `python\` (or your virtual environment) when you want to experiment interactively.
+
+## 7. Packaging Into a Wheel
+
+To generate a distributable wheel, run the helper script once the Release build completes:
+
+```bat
+python tools\package_wheel.py
+```
+
+The script will:
+1. Invoke CMake in Release mode if the project is not already built.
+2. Copy `yup_rive_renderer.pyd` into the Python packaging directory.
+3. Call `python -m build --wheel` inside `python\`, producing the wheel under `python\dist`.
+
+You can now install the wheel with:
+
+```bat
+python -m pip install --force-reinstall python\dist\yup-*.whl
+```
+
+---
+
+Following these steps gives any Windows developer a reliable, reproducible process for cloning, building, testing, and packaging the YUP renderer pipeline.

--- a/python/tests/test_integration_flow.py
+++ b/python/tests/test_integration_flow.py
@@ -1,0 +1,144 @@
+"""
+  ==============================================================================
+
+   This file is part of the YUP library.
+   Copyright (c) 2025 - kunitoki@gmail.com
+
+   YUP is an open source library subject to open-source licensing.
+
+   The code included in this file is provided under the terms of the ISC license
+   http://www.isc.org/downloads/software-support-policy/isc-license. Permission
+   to use, copy, modify, and/or distribute this software for any purpose with or
+   without fee is hereby granted provided that the above copyright notice and
+   this permission notice appear in all copies.
+
+   YUP IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
+   EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
+   DISCLAIMED.
+
+  ==============================================================================
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Mapping
+
+import pytest
+
+np = pytest.importorskip(
+    "numpy",
+    reason="NumPy is required for integration flow tests",
+)
+
+
+yup_rive_renderer = pytest.importorskip(
+    "yup_rive_renderer",
+    reason="yup_rive_renderer extension is not available",
+)
+
+from yup_ndi.orchestrator import NDIOrchestrator, NDIStreamConfig
+
+
+@dataclass
+class RecordedFrame:
+    width: int
+    height: int
+    stride: int
+    timestamp: int
+    array: np.ndarray
+
+
+class MockSenderHandle:
+    def __init__(self) -> None:
+        self.frames: List[RecordedFrame] = []
+        self.metadata: List[Mapping[str, Mapping[str, object]]] = []
+        self.closed = False
+
+    def write_video(self, buffer: memoryview, width: int, height: int, stride: int, timestamp: int) -> None:
+        flat = memoryview(buffer).cast("B")
+        frame_array = np.frombuffer(flat, dtype=np.uint8)
+        expected_size = height * stride
+        if frame_array.size != expected_size:
+            pytest.skip("Renderer did not expose a dense frame buffer")
+
+        if stride % 4 != 0:
+            pytest.skip("Frame stride is not aligned to 4-byte pixels")
+
+        row_pixels = stride // 4
+        frame_view = np.ndarray(
+            shape=(height, row_pixels, 4),
+            dtype=np.uint8,
+            buffer=flat,
+            strides=(stride, 4, 1),
+        )
+        self.frames.append(RecordedFrame(width, height, stride, timestamp, frame_view))
+
+    def send(self, buffer: memoryview, width: int, height: int, stride: int, timestamp: int) -> None:
+        self.write_video(buffer, width, height, stride, timestamp)
+
+    def apply_metadata(self, metadata: Mapping[str, Mapping[str, object]]) -> None:
+        if metadata:
+            self.metadata.append(metadata)
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def _build_renderer(width: int, height: int) -> "yup_rive_renderer.RiveOffscreenRenderer":
+    renderer = yup_rive_renderer.RiveOffscreenRenderer(width, height)
+    if not renderer.is_valid():
+        pytest.skip("RiveOffscreenRenderer backend is not initialised")
+    return renderer
+
+
+def test_renderer_to_orchestrator_frame_flow() -> None:
+    width = 256
+    height = 256
+    renderer = _build_renderer(width, height)
+
+    riv_path = Path(__file__).resolve().parents[3] / "examples" / "graphics" / "data" / "charge.riv"
+    if not riv_path.exists():
+        pytest.skip("Example Rive asset is missing")
+
+    sender_handle = MockSenderHandle()
+
+    def renderer_factory(config: NDIStreamConfig) -> "yup_rive_renderer.RiveOffscreenRenderer":
+        return renderer
+
+    def sender_factory(config: NDIStreamConfig, renderer_instance: object) -> MockSenderHandle:
+        return sender_handle
+
+    orchestrator = NDIOrchestrator(
+        renderer_factory=renderer_factory,
+        sender_factory=sender_factory,
+        timestamp_mapper=lambda seconds: int(seconds * 1_000_000),
+        time_provider=lambda: 0.0,
+    )
+
+    config = NDIStreamConfig(
+        name="integration",
+        width=width,
+        height=height,
+        riv_path=str(riv_path),
+        loop_animation=True,
+    )
+    orchestrator.add_stream(config)
+
+    frame_count = 3
+    for index in range(frame_count):
+        progressed = orchestrator.advance_stream("integration", 1.0 / 60.0, timestamp=float(index) / 60.0)
+        assert progressed is True
+
+    assert len(sender_handle.frames) == frame_count
+
+    for recorded in sender_handle.frames:
+        assert recorded.width == width
+        assert recorded.height == height
+        assert recorded.array.dtype == np.uint8
+        assert recorded.array.shape[0] == height
+        assert recorded.array.shape[2] == 4
+        assert recorded.array.shape[1] >= width
+
+    orchestrator.close()
+    assert sender_handle.closed is True

--- a/tools/benchmark_renderer.py
+++ b/tools/benchmark_renderer.py
@@ -1,0 +1,98 @@
+"""
+  ==============================================================================
+
+   This file is part of the YUP library.
+   Copyright (c) 2025 - kunitoki@gmail.com
+
+   YUP is an open source library subject to open-source licensing.
+
+   The code included in this file is provided under the terms of the ISC license
+   http://www.isc.org/downloads/software-support-policy/isc-license. Permission
+   to use, copy, modify, and/or distribute this software for any purpose with or
+   without fee is hereby granted provided that the above copyright notice and
+   this permission notice appear in all copies.
+
+   YUP IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
+   EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
+   DISCLAIMED.
+
+  ==============================================================================
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+import time
+from pathlib import Path
+
+import numpy as np
+
+
+DEFAULT_RIV = Path(__file__).resolve().parents[1] / "examples" / "graphics" / "data" / "charge.riv"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Benchmark yup_rive_renderer throughput and zero-copy behaviour.")
+    parser.add_argument("--frames", type=int, default=1000, help="Number of frames to render (default: %(default)s)")
+    parser.add_argument("--width", type=int, default=1920, help="Renderer width in pixels (default: %(default)s)")
+    parser.add_argument("--height", type=int, default=1080, help="Renderer height in pixels (default: %(default)s)")
+    parser.add_argument("--riv", type=Path, default=DEFAULT_RIV, help="Path to the Rive file to load (default: %(default)s)")
+    parser.add_argument("--delta", type=float, default=1.0 / 60.0, help="Delta time passed to advance() per frame (default: %(default)s)")
+    return parser.parse_args()
+
+
+def load_renderer(width: int, height: int, riv_path: Path):
+    try:
+        from yup_rive_renderer import RiveOffscreenRenderer
+    except ImportError as exc:  # pragma: no cover - exercised manually
+        print("[benchmark_renderer] ERROR: yup_rive_renderer extension is not available", file=sys.stderr)
+        raise SystemExit(1) from exc
+
+    renderer = RiveOffscreenRenderer(width, height)
+    if not renderer.is_valid():  # pragma: no cover - depends on environment
+        print("[benchmark_renderer] ERROR: RiveOffscreenRenderer backend is not initialised", file=sys.stderr)
+        raise SystemExit(1)
+
+    renderer.load_file(str(riv_path))
+    return renderer
+
+
+def benchmark(renderer, frames: int, delta: float) -> tuple[float, bool]:
+    addresses: set[int] = set()
+    start = time.perf_counter()
+
+    for _ in range(frames):
+        renderer.advance(delta)
+        view = renderer.acquire_frame_view()
+        flat = memoryview(view).cast("B")
+        array = np.frombuffer(flat, dtype=np.uint8)
+        addresses.add(int(array.__array_interface__["data"][0]))
+
+    elapsed = time.perf_counter() - start
+    zero_copy = len(addresses) == 1
+    return elapsed, zero_copy
+
+
+def main() -> int:
+    args = parse_args()
+    riv_path = args.riv
+
+    if not riv_path.exists():
+        print(f"[benchmark_renderer] ERROR: Rive file not found: {riv_path}", file=sys.stderr)
+        return 1
+
+    renderer = load_renderer(args.width, args.height, riv_path)
+
+    elapsed, zero_copy = benchmark(renderer, args.frames, args.delta)
+    fps = args.frames / elapsed if elapsed > 0 else float("inf")
+
+    print(f"Frames rendered: {args.frames}")
+    print(f"Total time: {elapsed:.3f} s")
+    print(f"Average FPS: {fps:.2f}")
+    print(f"Zero-Copy: {'PASSED' if zero_copy else 'FAILED'}")
+
+    return 0 if zero_copy else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/package_wheel.py
+++ b/tools/package_wheel.py
@@ -1,0 +1,151 @@
+"""
+  ==============================================================================
+
+   This file is part of the YUP library.
+   Copyright (c) 2025 - kunitoki@gmail.com
+
+   YUP is an open source library subject to open-source licensing.
+
+   The code included in this file is provided under the terms of the ISC license
+   http://www.isc.org/downloads/software-support-policy/isc-license. Permission
+   to use, copy, modify, and/or distribute this software for any purpose with or
+   without fee is hereby granted provided that the above copyright notice and
+   this permission notice appear in all copies.
+
+   YUP IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
+   EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
+   DISCLAIMED.
+
+  ==============================================================================
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Iterable, Sequence
+
+
+DEFAULT_BUILD_DIR = Path("build") / "wheel-release"
+TARGET_NAME = "yup_rive_renderer"
+
+
+class PackagingError(RuntimeError):
+    """Raised when an expected build artefact cannot be produced."""
+
+
+def run_command(command: Sequence[str], *, cwd: Path | None = None) -> None:
+    """Execute *command* and raise if it fails."""
+
+    print(f"[package_wheel] Running: {' '.join(command)}", flush=True)
+    subprocess.run(command, cwd=cwd, check=True)
+
+
+def configure_project(source_dir: Path, build_dir: Path) -> None:
+    """Configure the CMake project for a Release build."""
+
+    cmake_args = [
+        "cmake",
+        "-S",
+        str(source_dir),
+        "-B",
+        str(build_dir),
+        "-DCMAKE_BUILD_TYPE=Release",
+    ]
+
+    if sys.platform.startswith("win"):
+        generator = os.environ.get("CMAKE_GENERATOR", "Visual Studio 17 2022")
+        architecture = os.environ.get("CMAKE_GENERATOR_PLATFORM", "x64")
+        cmake_args.extend(["-G", generator, "-A", architecture])
+
+    build_dir.mkdir(parents=True, exist_ok=True)
+    run_command(cmake_args)
+
+
+def build_targets(build_dir: Path) -> None:
+    """Build the renderer module in Release mode."""
+
+    command = [
+        "cmake",
+        "--build",
+        str(build_dir),
+        "--target",
+        TARGET_NAME,
+    ]
+
+    if sys.platform.startswith("win"):
+        command.extend(["--config", "Release"])
+
+    run_command(command)
+
+
+def _iter_extension_candidates(build_dir: Path) -> Iterable[Path]:
+    suffixes = [".pyd", ".so", ".dylib"]
+    for suffix in suffixes:
+        yield from build_dir.rglob(f"{TARGET_NAME}{suffix}")
+
+
+def locate_extension(build_dir: Path) -> Path:
+    """Return the compiled extension module inside *build_dir*."""
+
+    for candidate in _iter_extension_candidates(build_dir):
+        if candidate.name.startswith(TARGET_NAME):
+            return candidate
+
+    raise PackagingError(
+        "Unable to locate the compiled yup_rive_renderer extension in the build directory."
+    )
+
+
+def copy_extension(module_path: Path, destination_root: Path) -> Path:
+    """Copy *module_path* into the Python packaging tree."""
+
+    destination_root.mkdir(parents=True, exist_ok=True)
+    destination = destination_root / module_path.name
+    print(f"[package_wheel] Copying {module_path} -> {destination}")
+    shutil.copy2(module_path, destination)
+    return destination
+
+
+def build_wheel(python_dir: Path) -> None:
+    """Invoke python -m build to produce the wheel."""
+
+    command = [sys.executable, "-m", "build", "--wheel"]
+    run_command(command, cwd=python_dir)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Build a distributable wheel for yup_rive_renderer.")
+    parser.add_argument(
+        "--build-dir",
+        type=Path,
+        default=DEFAULT_BUILD_DIR,
+        help="CMake build directory to use (default: %(default)s)",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    repo_root = Path(__file__).resolve().parents[1]
+    python_dir = repo_root / "python"
+
+    try:
+        configure_project(repo_root, args.build_dir)
+        build_targets(args.build_dir)
+        module_path = locate_extension(args.build_dir)
+        copy_extension(module_path, python_dir)
+        build_wheel(python_dir)
+    except (subprocess.CalledProcessError, PackagingError) as exc:
+        print(f"[package_wheel] ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    print("[package_wheel] Wheel build complete.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- add a comprehensive Windows 11 build and packaging walkthrough under docs
- provide helper scripts for wheel packaging and renderer benchmarking plus guidance in AGENTS.md
- introduce an integration test that exercises the renderer-to-orchestrator frame flow with mocked NDI output

## Testing
- pytest python/tests/test_integration_flow.py

------
https://chatgpt.com/codex/tasks/task_e_68d33b7ecfe8832980d5026a331e13ed