### PR TITLE
Add CLI and connection-aware orchestration features

### DIFF
--- a/python/yup_ndi/__init__.py
+++ b/python/yup_ndi/__init__.py
@@ -21,10 +21,11 @@ Runtime expectations:
 * The :mod:`yup_rive_renderer` extension must be built from this repository with
   `YUP_ENABLE_AUDIO_MODULES=OFF` as documented in ``docs/rive_ndi_overview.md``.
 
-The top-level API re-exports :class:`~yup_ndi.orchestrator.NDIOrchestrator` and
-:class:`~yup_ndi.orchestrator.NDIStreamConfig` for convenience.
+The top-level API re-exports :class:`~yup_ndi.orchestrator.NDIOrchestrator`,
+:class:`~yup_ndi.orchestrator.NDIStreamConfig`, and
+:class:`~yup_ndi.orchestrator.NDIStreamMetrics` for convenience.
 """
 
-from .orchestrator import NDIOrchestrator, NDIStreamConfig
+from .orchestrator import NDIOrchestrator, NDIStreamConfig, NDIStreamMetrics
 
-__all__ = ["NDIOrchestrator", "NDIStreamConfig"]
+__all__ = ["NDIOrchestrator", "NDIStreamConfig", "NDIStreamMetrics"]

--- a/python/yup_ndi/__main__.py
+++ b/python/yup_ndi/__main__.py
@@ -1,0 +1,28 @@
+"""
+  ==============================================================================
+
+   This file is part of the YUP library.
+   Copyright (c) 2025 - kunitoki@gmail.com
+
+   YUP is an open source library subject to open-source licensing.
+
+   The code included in this file is provided under the terms of the ISC license
+   http://www.isc.org/downloads/software-support-policy/isc-license. Permission
+   to use, copy, modify, and/or distribute this software for any purpose with or
+   without fee is hereby granted provided that the above copyright notice and
+   this permission notice appear in all copies.
+
+   YUP IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
+   EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
+   DISCLAIMED.
+
+  ==============================================================================
+"""
+
+from __future__ import annotations
+
+from .cli import main
+
+
+if __name__ == "__main__":  # pragma: no cover - module entry point
+    raise SystemExit(main())

--- a/python/yup_ndi/cli.py
+++ b/python/yup_ndi/cli.py
@@ -1,0 +1,246 @@
+"""
+  ==============================================================================
+
+   This file is part of the YUP library.
+   Copyright (c) 2025 - kunitoki@gmail.com
+
+   YUP is an open source library subject to open-source licensing.
+
+   The code included in this file is provided under the terms of the ISC license
+   http://www.isc.org/downloads/software-support-policy/isc-license. Permission
+   to use, copy, modify, and/or distribute this software for any purpose with or
+   without fee is hereby granted provided that the above copyright notice and
+   this permission notice appear in all copies.
+
+   YUP IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
+   EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
+   DISCLAIMED.
+
+  ==============================================================================
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import signal
+import sys
+import threading
+import time
+from typing import Any, Dict, Mapping, MutableMapping, Optional, Sequence
+
+from .orchestrator import NDIOrchestrator, NDIStreamConfig
+
+__all__ = ["main"]
+
+_logger = logging.getLogger(__name__)
+
+
+def _build_parser () -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Stream Rive animations to NDI using yup_ndi")
+    parser.add_argument("--name", required=True, help="NDI source name to publish")
+    parser.add_argument("--riv-file", required=True, help="Path to the .riv file to load")
+    parser.add_argument("--width", type=int, required=True, help="Renderer width in pixels")
+    parser.add_argument("--height", type=int, required=True, help="Renderer height in pixels")
+    parser.add_argument("--artboard", help="Optional artboard to select after loading the file")
+    parser.add_argument("--animation", help="Optional animation to play immediately")
+    parser.add_argument("--state-machine", help="Optional state machine to play immediately")
+    parser.add_argument("--no-loop", action="store_true", help="Disable looping when --animation is provided")
+    parser.add_argument("--fps", type=float, default=60.0, help="Frame rate to target; set to 0 to use wall-clock deltas")
+    parser.add_argument("--ndi-groups", default="", help="Comma-separated NDI group names")
+    parser.add_argument("--no-clock-video", dest="clock_video", action="store_false", default=True, help="Disable NDI video clocking")
+    parser.add_argument("--clock-audio", action="store_true", help="Enable NDI audio clocking")
+    parser.add_argument("--sender-option", action="append", default=[], metavar="KEY=VALUE", help="Additional cyndilib Sender options")
+    parser.add_argument("--metadata", action="append", default=[], metavar="KEY=VALUE", help="Metadata key/value pairs published under the 'ndi' tag")
+    parser.add_argument("--state-input", action="append", default=[], metavar="NAME=VALUE", help="Initial state machine input values")
+    parser.add_argument("--sync-send", dest="use_async_send", action="store_false", default=True, help="Send frames synchronously instead of using cyndilib's async queue")
+    parser.add_argument("--no-throttle", dest="throttle_when_inactive", action="store_false", default=True, help="Continue rendering even when no NDI receivers are connected")
+    parser.add_argument("--pause-when-inactive", action="store_true", help="Pause the renderer when no NDI receivers are connected")
+    parser.add_argument("--poll-interval", type=float, default=1.0, help="Seconds between connection-count polls when throttling is enabled")
+    parser.add_argument("--rest-host", default="127.0.0.1", help="Host interface for the optional REST control server")
+    parser.add_argument("--rest-port", type=int, help="Port for the optional REST control server")
+    parser.add_argument("--osc-host", default="127.0.0.1", help="Host interface for the optional OSC control server")
+    parser.add_argument("--osc-port", type=int, help="Port for the optional OSC control server")
+    parser.add_argument("--osc-namespace", default="/ndi", help="OSC namespace prefix (default: /ndi)")
+    parser.add_argument("--log-level", default="INFO", help="Python logging level (default: INFO)")
+    parser.add_argument("--metrics-interval", type=float, default=10.0, help="Seconds between periodic metrics logs; set to 0 to disable")
+    return parser
+
+
+def _parse_key_value_pairs (pairs: Sequence[str], option: str) -> Dict[str, str]:
+    result: Dict[str, str] = {}
+    for pair in pairs:
+        if "=" not in pair:
+            raise ValueError(f"{option} expects KEY=VALUE entries; received '{pair}'")
+        key, value = pair.split("=", 1)
+        result[key.strip()] = value.strip()
+    return result
+
+
+def _parse_state_inputs (pairs: Sequence[str]) -> MutableMapping[str, Any]:
+    inputs: MutableMapping[str, Any] = {}
+    for pair in pairs:
+        if "=" not in pair:
+            raise ValueError(f"--state-input expects NAME=VALUE entries; received '{pair}'")
+        name, value = pair.split("=", 1)
+        inputs[name.strip()] = _coerce_scalar(value.strip())
+    return inputs
+
+
+def _coerce_scalar (value: str) -> Any:
+    lowered = value.lower()
+    if lowered in {"true", "false"}:
+        return lowered == "true"
+
+    try:
+        return int(value)
+    except ValueError:
+        try:
+            return float(value)
+        except ValueError:
+            return value
+
+
+class _FramePump:
+    def __init__ (
+        self,
+        orchestrator: NDIOrchestrator,
+        stream_name: str,
+        target_fps: float,
+        metrics_interval: float,
+    ) -> None:
+        self._orchestrator = orchestrator
+        self._stream_name = stream_name
+        self._delta = 1.0 / target_fps if target_fps > 0 else None
+        self._metrics_interval = metrics_interval
+        self._stop_event = threading.Event()
+
+    def stop (self) -> None:
+        self._stop_event.set()
+
+    def run (self) -> None:
+        previous_time = time.perf_counter()
+        last_metrics = time.monotonic()
+
+        def _handle_signal (signum: int, frame: Optional[object]) -> None:  # pragma: no cover - signal handler
+            _logger.info("Received signal %s; stopping", signum)
+            self._stop_event.set()
+
+        original_int = signal.getsignal(signal.SIGINT)
+        original_term = signal.getsignal(signal.SIGTERM)
+        signal.signal(signal.SIGINT, _handle_signal)
+        signal.signal(signal.SIGTERM, _handle_signal)
+
+        try:
+            while not self._stop_event.is_set() and self._stream_name in self._orchestrator.list_streams():
+                now = time.perf_counter()
+                delta = self._delta if self._delta is not None else max(0.0, now - previous_time)
+                timestamp = now
+                try:
+                    self._orchestrator.advance_stream(self._stream_name, delta, timestamp)
+                except KeyError:
+                    _logger.error("Stream '%s' is no longer registered", self._stream_name)
+                    break
+
+                previous_time = now if self._delta is None else previous_time + self._delta
+
+                if self._metrics_interval > 0 and (time.monotonic() - last_metrics) >= self._metrics_interval:
+                    metrics = self._orchestrator.get_stream_metrics(self._stream_name)
+                    _logger.info(
+                        "Stream %s → sent=%d suppressed=%d connections=%d paused=%s",
+                        self._stream_name,
+                        metrics.frames_sent,
+                        metrics.frames_suppressed,
+                        metrics.last_connection_count,
+                        metrics.paused_for_inactivity,
+                    )
+                    last_metrics = time.monotonic()
+
+                if self._delta is not None:
+                    elapsed = time.perf_counter() - now
+                    sleep_time = self._delta - elapsed
+                    if sleep_time > 0:
+                        time.sleep(sleep_time)
+                else:
+                    time.sleep(0)
+        except KeyboardInterrupt:  # pragma: no cover - interactive guard
+            _logger.info("Stopping due to keyboard interrupt")
+        finally:
+            signal.signal(signal.SIGINT, original_int)
+            signal.signal(signal.SIGTERM, original_term)
+
+
+def main (argv: Optional[Sequence[str]] = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(level=getattr(logging, args.log_level.upper(), logging.INFO))
+
+    try:
+        sender_options = _parse_key_value_pairs(args.sender_option, "--sender-option")
+        metadata_pairs = _parse_key_value_pairs(args.metadata, "--metadata")
+        state_inputs = _parse_state_inputs(args.state_input)
+    except ValueError as exc:
+        parser.error(str(exc))
+
+    metadata: MutableMapping[str, Mapping[str, Any]] = {}
+    if metadata_pairs:
+        metadata["ndi"] = metadata_pairs
+
+    frame_rate: Optional[float] = args.fps if args.fps > 0 else None
+
+    config = NDIStreamConfig(
+        name=args.name,
+        width=args.width,
+        height=args.height,
+        riv_path=args.riv_file,
+        artboard=args.artboard,
+        animation=args.animation,
+        loop_animation=not args.no_loop,
+        state_machine=args.state_machine,
+        frame_rate=frame_rate,
+        ndi_groups=args.ndi_groups,
+        clock_video=args.clock_video,
+        clock_audio=args.clock_audio,
+        sender_options=dict(sender_options),
+        metadata=metadata,
+        state_machine_inputs=state_inputs,
+        use_async_send=args.use_async_send,
+        throttle_when_inactive=args.throttle_when_inactive,
+        pause_when_inactive=args.pause_when_inactive,
+        inactive_connection_poll_interval=max(0.0, args.poll_interval),
+    )
+
+    orchestrator = NDIOrchestrator()
+    orchestrator.add_stream(config)
+
+    active_servers: list[Any] = []
+
+    if args.rest_port is not None:
+        from .rest_server import start_rest_server
+
+        active_servers.append(start_rest_server(orchestrator, host=args.rest_host, port=args.rest_port))
+
+    if args.osc_port is not None:
+        from .osc_server import start_osc_server
+
+        active_servers.append(start_osc_server(orchestrator, host=args.osc_host, port=args.osc_port, namespace=args.osc_namespace))
+
+    pump = _FramePump(orchestrator, args.name, args.fps, args.metrics_interval)
+
+    try:
+        pump.run()
+    finally:
+        pump.stop()
+        for server in active_servers:
+            try:
+                server.close()
+            except Exception:  # pragma: no cover - shutdown best effort
+                _logger.exception("Failed to stop control server cleanly")
+        orchestrator.close()
+
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation
+    sys.exit(main())

--- a/python/yup_ndi/osc_server.py
+++ b/python/yup_ndi/osc_server.py
@@ -1,0 +1,181 @@
+"""
+  ==============================================================================
+
+   This file is part of the YUP library.
+   Copyright (c) 2025 - kunitoki@gmail.com
+
+   YUP is an open source library subject to open-source licensing.
+
+   The code included in this file is provided under the terms of the ISC license
+   http://www.isc.org/downloads/software-support-policy/isc-license. Permission
+   to use, copy, modify, and/or distribute this software for any purpose with or
+   without fee is hereby granted provided that the above copyright notice and
+   this permission notice appear in all copies.
+
+   YUP IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
+   EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
+   DISCLAIMED.
+
+  ==============================================================================
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import threading
+from typing import Any, Dict, Mapping, Sequence
+
+from .orchestrator import NDIOrchestrator
+
+__all__ = ["OscControlServer", "start_osc_server"]
+
+_logger = logging.getLogger(__name__)
+
+
+class OscControlServer:
+    """Expose :class:`NDIOrchestrator` controls via Open Sound Control messages."""
+
+    def __init__ (
+        self,
+        orchestrator: NDIOrchestrator,
+        host: str = "127.0.0.1",
+        port: int = 5001,
+        namespace: str = "/ndi",
+    ) -> None:
+        try:  # pragma: no cover - exercised when python-osc is installed
+            from pythonosc.dispatcher import Dispatcher
+            from pythonosc.osc_server import ThreadingOSCUDPServer
+        except ImportError as exc:  # pragma: no cover - import guard
+            raise ImportError("python-osc is required for the OSC control server; install python-osc>=1.8") from exc
+
+        self._orchestrator = orchestrator
+        self._host = host
+        self._port = port
+        base_namespace = namespace.strip("/")
+        self._namespace = f"/{base_namespace}" if base_namespace else "/ndi"
+        self._dispatcher = Dispatcher()
+        self._dispatcher.map(f"{self._namespace}/*/control", self._handle_control)
+        self._dispatcher.map(f"{self._namespace}/*/metrics", self._handle_metrics)
+        self._server_factory = ThreadingOSCUDPServer
+        self._server: Any = None
+        self._thread: threading.Thread | None = None
+
+    def __enter__ (self) -> "OscControlServer":
+        self.start()
+        return self
+
+    def __exit__ (self, exc_type, exc, tb) -> None:
+        self.close()
+
+    def start (self) -> None:
+        if self._server is not None:
+            return
+
+        self._server = self._server_factory((self._host, self._port), self._dispatcher)
+        self._server.daemon_threads = True
+        self._thread = threading.Thread(target=self._server.serve_forever, name="yup-osc-control", daemon=True)
+        self._thread.start()
+        _logger.info("OSC control server listening on %s:%d%s", self._host, self._port, self._namespace)
+
+    def close (self) -> None:
+        if self._server is None:
+            return
+
+        _logger.info("Stopping OSC control server on %s:%d%s", self._host, self._port, self._namespace)
+        self._server.shutdown()
+        if self._thread is not None:
+            self._thread.join(timeout=2.0)
+        self._server = None
+        self._thread = None
+
+    def _handle_control (self, address: str, *args: Any) -> None:
+        stream_name = self._extract_stream_name(address)
+        if stream_name is None:
+            _logger.warning("Ignoring OSC control for malformed address '%s'", address)
+            return
+
+        if not args:
+            _logger.warning("OSC control for '%s' missing action argument", stream_name)
+            return
+
+        action = str(args[0])
+        parameters = self._coerce_parameters(args[1:])
+
+        try:
+            self._orchestrator.apply_stream_control(stream_name, action, parameters)
+        except KeyError:
+            _logger.warning("OSC control target stream '%s' not found", stream_name)
+        except Exception:  # pragma: no cover - runtime guard
+            _logger.exception("OSC control failed for stream '%s'", stream_name)
+
+    def _handle_metrics (self, address: str, *args: Any) -> None:
+        stream_name = self._extract_stream_name(address)
+        if stream_name is None:
+            _logger.warning("Ignoring OSC metrics request for malformed address '%s'", address)
+            return
+
+        try:
+            metrics = self._orchestrator.get_stream_metrics(stream_name)
+        except KeyError:
+            _logger.warning("OSC metrics target stream '%s' not found", stream_name)
+            return
+
+        payload = {
+            "frames_sent": metrics.frames_sent,
+            "frames_suppressed": metrics.frames_suppressed,
+            "connections": metrics.last_connection_count,
+            "paused": metrics.paused_for_inactivity,
+        }
+        _logger.info("OSC metrics for %s: %s", stream_name, payload)
+
+    def _extract_stream_name (self, address: str) -> str | None:
+        parts = address.strip("/").split("/")
+        if len(parts) < 3:
+            return None
+        if parts[0] != self._namespace.strip("/"):
+            return None
+        return parts[1]
+
+    def _coerce_parameters (self, args: Sequence[Any]) -> Mapping[str, Any]:
+        if not args:
+            return {}
+
+        first = args[0]
+        if isinstance(first, Mapping):
+            return dict(first)
+
+        if isinstance(first, str):
+            try:
+                decoded = json.loads(first)
+            except json.JSONDecodeError:
+                decoded = None
+            if isinstance(decoded, Mapping):
+                return dict(decoded)
+            if len(args) == 1:
+                return {"value": first}
+
+        if len(args) % 2 == 0:
+            parameters: Dict[str, Any] = {}
+            for index in range(0, len(args), 2):
+                key = str(args[index])
+                parameters[key] = args[index + 1]
+            return parameters
+
+        return {"value": first}
+
+    def __repr__ (self) -> str:
+        return f"OscControlServer(host={self._host!r}, port={self._port!r}, namespace={self._namespace!r})"
+
+
+def start_osc_server (
+    orchestrator: NDIOrchestrator,
+    host: str = "127.0.0.1",
+    port: int = 5001,
+    namespace: str = "/ndi",
+) -> OscControlServer:
+    """Create and start an :class:`OscControlServer` instance."""
+
+    server = OscControlServer(orchestrator, host=host, port=port, namespace=namespace)
+    server.start()
+    return server

--- a/python/yup_ndi/rest_server.py
+++ b/python/yup_ndi/rest_server.py
@@ -1,0 +1,162 @@
+"""
+  ==============================================================================
+
+   This file is part of the YUP library.
+   Copyright (c) 2025 - kunitoki@gmail.com
+
+   YUP is an open source library subject to open-source licensing.
+
+   The code included in this file is provided under the terms of the ISC license
+   http://www.isc.org/downloads/software-support-policy/isc-license. Permission
+   to use, copy, modify, and/or distribute this software for any purpose with or
+   without fee is hereby granted provided that the above copyright notice and
+   this permission notice appear in all copies.
+
+   YUP IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
+   EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
+   DISCLAIMED.
+
+  ==============================================================================
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import logging
+import threading
+from typing import Any, Mapping, Optional
+
+from .orchestrator import NDIOrchestrator
+
+__all__ = ["RestControlServer", "start_rest_server"]
+
+_logger = logging.getLogger(__name__)
+
+
+class RestControlServer:
+    """Expose :class:`NDIOrchestrator` controls over a small Flask REST API."""
+
+    def __init__ (self, orchestrator: NDIOrchestrator, host: str = "127.0.0.1", port: int = 5000) -> None:
+        try:  # pragma: no cover - exercised when Flask is available
+            from flask import Flask, jsonify, request
+            from werkzeug.serving import make_server
+        except ImportError as exc:  # pragma: no cover - import guard
+            raise ImportError("Flask is required for the REST control server; install flask>=2.3") from exc
+
+        self._orchestrator = orchestrator
+        self._host = host
+        self._port = port
+        self._app = Flask(__name__)
+        self._jsonify = jsonify
+        self._request = request
+        self._make_server = make_server
+        self._server = None
+        self._thread: Optional[threading.Thread] = None
+
+        self._register_routes()
+
+    def __enter__ (self) -> "RestControlServer":
+        self.start()
+        return self
+
+    def __exit__ (self, exc_type, exc, tb) -> None:
+        self.close()
+
+    def start (self) -> None:
+        if self._server is not None:
+            return
+
+        self._server = self._make_server(self._host, self._port, self._app)
+        self._server.daemon_threads = True
+        self._thread = threading.Thread(target=self._serve_forever, name="yup-rest-control", daemon=True)
+        self._thread.start()
+        _logger.info("REST control server listening on http://%s:%d", self._host, self._port)
+
+    def close (self) -> None:
+        if self._server is None:
+            return
+
+        _logger.info("Stopping REST control server on http://%s:%d", self._host, self._port)
+        self._server.shutdown()
+        if self._thread is not None:
+            self._thread.join(timeout=2.0)
+        self._server = None
+        self._thread = None
+
+    def _serve_forever (self) -> None:
+        assert self._server is not None
+        try:
+            self._server.serve_forever()
+        except Exception:  # pragma: no cover - background server loop
+            _logger.exception("REST control server terminated unexpectedly")
+
+    def _register_routes (self) -> None:
+        app = self._app
+
+        @app.get("/health")
+        def health () -> Any:
+            return self._jsonify({"status": "ok"})
+
+        @app.get("/streams")
+        def list_streams () -> Any:
+            payload = {
+                name: dataclasses.asdict(self._orchestrator.get_stream_metrics(name))
+                for name in self._orchestrator.list_streams()
+            }
+            return self._jsonify({"streams": payload})
+
+        @app.get("/streams/<name>")
+        def get_stream (name: str) -> Any:
+            try:
+                metrics = dataclasses.asdict(self._orchestrator.get_stream_metrics(name))
+            except KeyError:
+                return self._jsonify({"error": f"Stream '{name}' not found"}), 404
+            return self._jsonify({"name": name, "metrics": metrics})
+
+        @app.post("/streams/<name>/control")
+        def control_stream (name: str) -> Any:
+            payload = self._request.get_json(force=True, silent=True) or {}
+            action = payload.get("action")
+            if not action:
+                return self._jsonify({"error": "Request body must include an 'action'"}), 400
+
+            parameters = payload.get("parameters") or {}
+            if not isinstance(parameters, Mapping):
+                return self._jsonify({"error": "'parameters' must be a mapping"}), 400
+
+            try:
+                result = self._orchestrator.apply_stream_control(name, action, parameters)
+            except KeyError:
+                return self._jsonify({"error": f"Stream '{name}' not found"}), 404
+            except Exception as exc:  # pragma: no cover - runtime guard
+                _logger.exception("REST control failed for stream '%s'", name)
+                return self._jsonify({"error": str(exc)}), 400
+
+            return self._jsonify({"result": result})
+
+        @app.post("/streams/<name>/metadata")
+        def metadata_stream (name: str) -> Any:
+            payload = self._request.get_json(force=True, silent=True)
+            if not isinstance(payload, Mapping):
+                return self._jsonify({"error": "Metadata payload must be a mapping"}), 400
+
+            try:
+                self._orchestrator.apply_stream_metadata(name, payload)  # type: ignore[arg-type]
+            except KeyError:
+                return self._jsonify({"error": f"Stream '{name}' not found"}), 404
+            except Exception as exc:  # pragma: no cover - runtime guard
+                _logger.exception("Failed to apply metadata for stream '%s'", name)
+                return self._jsonify({"error": str(exc)}), 400
+
+            return self._jsonify({"status": "ok"})
+
+    def __repr__ (self) -> str:
+        return f"RestControlServer(host={self._host!r}, port={self._port!r})"
+
+
+def start_rest_server (orchestrator: NDIOrchestrator, host: str = "127.0.0.1", port: int = 5000) -> RestControlServer:
+    """Create and start a :class:`RestControlServer` instance."""
+
+    server = RestControlServer(orchestrator, host=host, port=port)
+    server.start()
+    return server


### PR DESCRIPTION
## Summary
- release the Python GIL during renderer load and advance operations to improve host responsiveness
- extend the NDI orchestrator with connection-aware throttling/metrics plus REST and OSC control servers
- add a yup_ndi CLI entry point, update the guide, and expand the pytest coverage for throttling scenarios

## Testing
- pytest python/tests/test_yup_ndi/test_orchestrator.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d33fe472b483299b84a177b65fdfae