### PR TITLE
Support fractional CLI frame rate parsing

### DIFF
--- a/docs/Rive to NDI Guide.md
+++ b/docs/Rive to NDI Guide.md
@@ -103,8 +103,12 @@ script. Invoke it with `python -m yup_ndi` and supply the renderer dimensions pl
 
 ```powershell
 python -m yup_ndi --name StudioA --riv-file assets/demo.riv --width 1920 --height 1080 \
-    --animation Loop --ndi-groups ControlRoom --fps 59.94 --rest-port 5000 --osc-port 5001
+    --animation Loop --ndi-groups ControlRoom --fps 60000/1001 --rest-port 5000 --osc-port 5001
 ```
+
+`--fps` accepts either decimal values (e.g. `59.94`) or exact ratios such as `60000/1001` so you
+can preserve broadcast frame cadences when configuring NDI senders. Passing `0` keeps the renderer
+in wall-clock mode, matching the CLI's legacy behaviour.
 
 The CLI supports the same configuration payload as `NDIStreamConfig`, including `--state-input`
 pairs, connection throttling toggles, and optional REST/OSC servers:

--- a/python/tests/test_yup_ndi/test_cli.py
+++ b/python/tests/test_yup_ndi/test_cli.py
@@ -1,0 +1,58 @@
+"""
+  ==============================================================================
+
+   This file is part of the YUP library.
+   Copyright (c) 2025 - kunitoki@gmail.com
+
+   YUP is an open source library subject to open-source licensing.
+
+   The code included in this file is provided under the terms of the ISC license
+   http://www.isc.org/downloads/software-support-policy/isc-license. Permission
+   to use, copy, modify, and/or distribute this software for any purpose with or
+   without fee is hereby granted provided that the above copyright notice and
+   this permission notice appear in all copies.
+
+   YUP IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
+   EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
+   DISCLAIMED.
+
+  ==============================================================================
+"""
+
+from __future__ import annotations
+
+from fractions import Fraction
+
+import pytest
+
+import yup_ndi.cli as cli
+
+
+def test_parse_frame_rate_fraction_string () -> None:
+    fraction, cadence = cli._parse_frame_rate("60000/1001")
+    assert fraction == Fraction(60000, 1001)
+    assert cadence == pytest.approx(60000 / 1001)
+
+
+def test_parse_frame_rate_decimal_string () -> None:
+    fraction, cadence = cli._parse_frame_rate("59.94")
+    assert fraction == Fraction(2997, 50)
+    assert cadence == pytest.approx(59.94)
+
+
+def test_parse_frame_rate_zero_disables () -> None:
+    fraction, cadence = cli._parse_frame_rate("0")
+    assert fraction is None
+    assert cadence is None
+
+
+def test_parse_frame_rate_rejects_invalid_input () -> None:
+    with pytest.raises(ValueError):
+        cli._parse_frame_rate("not-a-number")
+
+
+def test_parse_frame_rate_accepts_fraction_instance () -> None:
+    rate = Fraction(24, 1)
+    fraction, cadence = cli._parse_frame_rate(rate)
+    assert fraction == rate
+    assert cadence == pytest.approx(24.0)

--- a/python/tests/test_yup_ndi/test_orchestrator.py
+++ b/python/tests/test_yup_ndi/test_orchestrator.py
@@ -159,6 +159,12 @@ class FakeFactories:
         return handle
 
 
+def test_stream_config_accepts_fraction_ratio () -> None:
+    rate = Fraction(60000, 1001)
+    config = NDIStreamConfig(name="frac", width=1, height=1, riv_bytes=b"riv", frame_rate=rate)
+    assert config.frame_rate is rate
+
+
 def test_orchestrator_advances_and_sends_frames () -> None:
     factories = FakeFactories()
     orchestrator = NDIOrchestrator(
@@ -704,6 +710,7 @@ def test_default_factories_wire_renderer_and_sender (monkeypatch: pytest.MonkeyP
     assert sender.video_frame is not None
     assert sender.video_frame.fourcc == "BGRA"
     assert sender.video_frame.resolutions[-1] == (2, 2)
+    assert sender.video_frame.frame_rate == Fraction(30000, 1001)
     assert sender.open_called is True
 
     progressed = orchestrator.advance_stream("default", 0.25, timestamp=1.0)

--- a/python/yup_ndi/orchestrator.py
+++ b/python/yup_ndi/orchestrator.py
@@ -118,11 +118,13 @@ class NDIStreamConfig:
         if self.width <= 0 or self.height <= 0:
             raise ValueError("Renderer dimensions must be positive")
 
-        if isinstance(self.frame_rate, tuple):
+        if isinstance(self.frame_rate, Fraction):
+            pass
+        elif isinstance(self.frame_rate, tuple):
             self.frame_rate = Fraction(self.frame_rate[0], self.frame_rate[1])
-        elif isinstance(self.frame_rate, float):
+        elif isinstance(self.frame_rate, (float, int)):
             self.frame_rate = Fraction(self.frame_rate).limit_denominator()
-        elif self.frame_rate is not None and not isinstance(self.frame_rate, Fraction):
+        elif self.frame_rate is not None:
             raise TypeError("frame_rate must be a Fraction, float, tuple, or None")
 
         if self.inactive_connection_poll_interval < 0:


### PR DESCRIPTION
## Summary
- teach the CLI to parse --fps values such as 60000/1001, returning both a Fraction for NDIStreamConfig and a float cadence for the frame pump
- relax NDIStreamConfig validation to preserve pre-parsed Fraction inputs and extend coverage for the new parsing helper
- document the ratio syntax in the Rive to NDI guide alongside the new unit tests

## Testing
- pytest python/tests/test_yup_ndi -q

------
https://chatgpt.com/codex/tasks/task_e_68d347f1e5e08329b7dfd8431536d54f