### PR TITLE
Anchor fractional NDI timestamps to explicit start times

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,16 @@ You are extending YUP to deliver a Windows-focused pipeline that renders Rive (`
 | Documentation & developer workflow | ⚠️ Needs expansion in `docs/` and `tools/` to describe Windows build steps, wheel packaging, and orchestration usage. |
 
 ## Documentation Cross-References
+- **Mandatory:** ALWAYS update the relevant documentation whenever you change code. Every feature, bug
+  fix, or behaviour tweak must be reflected in the docs before the worktree is considered complete.
+- **Primary documentation entry points:**
+  - `README.md` – quickstart build/test recipes and API overview.
+  - `docs/rive_ndi_overview.md` – Windows-focused walkthrough of the renderer → NDI flow.
+  - `docs/Rive to NDI Guide.md` – detailed step-by-step orchestration and tooling guide.
+  - `docs/Windows Build and Packaging.md` – MSVC toolchain, packaging, and release notes.
+  - `docs/BUILD_WINDOWS.md` – legacy but still-referenced Windows build primer.
+  - `docs/Building Plugins.md` and `docs/Building Standalone.md` – ancillary build targets.
+  - `docs/YUP Module Format.md` – module metadata expectations.
 - **Quick orientation:** Start with the redundancy-pruning checklist in `README.md` to understand the trim plan for legacy modules and the guardrails that must remain while focusing on the Rive → NDI path.
 - **Rive → NDI flow:** The canonical walkthrough lives in `docs/Rive to NDI Guide.md`. It maps renderer classes to Python bindings, calls out the minimal module surface needed for transmission, and links TODOs for each subsystem.
 - **Legacy dependency audit:** Inline breadcrumbs inside `modules/yup_gui/artboard/yup_RiveOffscreenRenderer.*` and `python/yup_ndi/orchestrator.py` enumerate bindings/tests that must stay aligned if refactors delete surrounding helpers.

--- a/docs/Rive to NDI Guide.md
+++ b/docs/Rive to NDI Guide.md
@@ -102,6 +102,12 @@ Use `apply_stream_control()` to pause/resume playback, select artboards, or set 
 at runtime. Register custom control handlers via `register_control_handler()` if you expose REST/OSC
 interfaces above the orchestrator.
 
+> [!IMPORTANT]
+> When you configure a `frame_rate`, use `NDIOrchestrator.set_stream_start_time()` (or pass the
+> optional `start_time` keyword to `add_stream()`) to anchor the deterministic 100 ns timeline before
+> sending the first frame. This prevents drift when pumping fractional rates such as 30000/1001. The
+> CLI's frame pump captures a monotonic start time and primes the stream automatically.
+
 `renderer_options` accepts a `staging_buffer_count` entry that forwards to the renderer constructor,
 mirroring the direct Python API. Set it to a higher value when streams are consumed asynchronously or
 when a few extra milliseconds of buffering keeps throughput stable. Invalid or missing entries fall

--- a/docs/rive_ndi_overview.md
+++ b/docs/rive_ndi_overview.md
@@ -32,7 +32,10 @@ frames as bytes or `memoryview` objects without copying when possible. Callers c
 `staging_buffer_count` to control how many readback textures the renderer cycles through before data is
 reused.
 3. **Publish over NDI:** `yup_ndi.NDIOrchestrator` instantiates renderers, maps timestamps into the
-100 ns NDI domain, forwards frames to `cyndilib` senders, and applies metadata/control commands.
+100 ns NDI domain, forwards frames to `cyndilib` senders, and applies metadata/control commands. Use
+`set_stream_start_time()` (or the optional `start_time` argument on `add_stream()`) to prime the
+deterministic timestamp anchor when driving fractional frame rates so frames align to a consistent
+monotonic origin. The CLI frame pump wires this up automatically before emitting the first frame.
 
 The orchestrator also exposes a `renderer_options` dictionary so deployments can request deeper staging
 queues when buffering bursts or multiple consumers is preferable to the lowest possible latency.


### PR DESCRIPTION
## Summary
- allow callers to seed deterministic NDI timelines via `NDIOrchestrator.set_stream_start_time` or the new `start_time` parameter on `add_stream`
- update the CLI frame pump to prime the stream anchor before the first send and add regression coverage for the new API hook
- document the start-time workflow in the Rive→NDI guides and reinforce the documentation policy in `AGENTS.md`

## Testing
- `pytest python/tests/test_yup_ndi/test_orchestrator.py`
- `pytest python/tests/test_integration_flow.py`


------
https://chatgpt.com/codex/tasks/task_e_68d34edd839c8329a46227cfb8e5bc9d