### PR TITLE
Optimize fractional timestamp generation

### DIFF
--- a/docs/rive_ndi_overview.md
+++ b/docs/rive_ndi_overview.md
@@ -35,10 +35,12 @@ frames as bytes or `memoryview` objects without copying when possible. Callers c
 `staging_buffer_count` to control how many readback textures the renderer cycles through before data is
 reused.
 3. **Publish over NDI:** `yup_ndi.NDIOrchestrator` instantiates renderers, maps timestamps into the
-100 ns NDI domain, forwards frames to `cyndilib` senders, and applies metadata/control commands. Use
-`set_stream_start_time()` (or the optional `start_time` argument on `add_stream()`) to prime the
-deterministic timestamp anchor when driving fractional frame rates so frames align to a consistent
-monotonic origin. The CLI frame pump wires this up automatically before emitting the first frame.
+100 ns NDI domain, forwards frames to `cyndilib` senders, and applies metadata/control commands. The
+stream timeline now uses a fixed-point accumulator, avoiding per-frame `Fraction` arithmetic while
+keeping deterministic cadence for fractional frame rates. Use `set_stream_start_time()` (or the
+optional `start_time` argument on `add_stream()`) to prime the deterministic timestamp anchor so
+frames align to a consistent monotonic origin. The CLI frame pump wires this up automatically before
+emitting the first frame.
 
 The orchestrator also exposes a `renderer_options` dictionary so deployments can request deeper staging
 queues when buffering bursts or multiple consumers is preferable to the lowest possible latency.


### PR DESCRIPTION
## Summary
- replace per-frame Fraction timestamp math in the NDI stream timeline with an integer accumulator for lower overhead
- document the new fixed-point accumulator in the Rive → NDI overview

## Testing
- pytest python/tests/test_yup_ndi/test_orchestrator.py

------
https://chatgpt.com/codex/tasks/task_e_68d3ac3f17188329a5c61132496e665d