### PR TITLE
Fix DirectSound sleep usage for Windows builds

### DIFF
--- a/docs/Windows Build and Packaging.md
+++ b/docs/Windows Build and Packaging.md
@@ -100,3 +100,11 @@ when GPU or NDI runtimes are absent.
   before invoking `just python_wheel` or `python -m build`.
 - Cache the `build/` and `.venv/` folders between CI runs to avoid repeated CMake
   configuration and dependency installation costs.
+
+## Troubleshooting
+
+- **`'sleep': identifier not found` during the audio device build** – The Windows toolchain
+  does not provide the POSIX `sleep()` symbol, so any backend that still calls it will fail
+  to compile. Replace raw `sleep()`/`Sleep()` usages in platform code (e.g. the DirectSound
+  backend) with `Thread::sleep(milliseconds)` so the implementation maps cleanly onto the
+  Windows API.

--- a/modules/yup_audio_devices/native/yup_ALSA_linux.cpp
+++ b/modules/yup_audio_devices/native/yup_ALSA_linux.cpp
@@ -637,7 +637,7 @@ public:
 
         while (numCallbacks == 0)
         {
-            sleep (5);
+            Thread::sleep (5);
 
             if (--count < 0 || ! isThreadRunning())
             {

--- a/modules/yup_audio_devices/native/yup_DirectSound_windows.cpp
+++ b/modules/yup_audio_devices/native/yup_DirectSound_windows.cpp
@@ -1071,7 +1071,7 @@ private:
     {
         if (! threadShouldExit())
         {
-            sleep (5);
+            Thread::sleep (5);
 
             for (int i = 0; i < outChans.size(); ++i)
                 outChans.getUnchecked (i)->synchronisePosition();
@@ -1150,7 +1150,7 @@ public:
 
                     if (--count <= 0)
                     {
-                        Sleep (1);
+                        Thread::sleep (1);
                         count = maxCount;
                     }
 
@@ -1160,7 +1160,7 @@ public:
             }
             else
             {
-                sleep (1);
+                Thread::sleep (1);
             }
 
             const ScopedLock sl (startStopLock);
@@ -1177,7 +1177,7 @@ public:
             else
             {
                 outputBuffers.clear();
-                sleep (1);
+                Thread::sleep (1);
             }
         }
     }
@@ -1356,7 +1356,7 @@ String DSoundAudioIODevice::openDevice (const BigInteger& inputChannels,
             inChans.getUnchecked (i)->synchronisePosition();
 
         startThread (Priority::highest);
-        sleep (10);
+        Thread::sleep (10);
 
         notify();
     }

--- a/modules/yup_core/threads/yup_Thread.cpp
+++ b/modules/yup_core/threads/yup_Thread.cpp
@@ -245,7 +245,7 @@ bool Thread::waitForThreadToExit (const int timeOutMilliseconds) const
         if (timeOutMilliseconds >= 0 && Time::getMillisecondCounter() > timeoutEnd)
             return false;
 
-        sleep (2);
+        Thread::sleep (2);
     }
 
     return true;


### PR DESCRIPTION
## Summary
- replace raw sleep() and Sleep() calls in the DirectSound backend with Thread::sleep so the code builds with MSVC
- update the ALSA backend and thread shutdown helper to use the common Thread::sleep wrapper
- document the Windows troubleshooting note explaining the sleep() build failure and the preferred fix

## Testing
- not run (not supported in container)


------
https://chatgpt.com/codex/tasks/task_e_68d44eb45d3483298eb044afaed8d0ed