### PR TITLE
Add standalone Rive→NDI prototype control panel

### DIFF
--- a/docs/Rive to NDI Guide.md
+++ b/docs/Rive to NDI Guide.md
@@ -175,3 +175,18 @@ When modifying the renderer API, update the bindings and tests in the same commi
 - **Black frames or zero-sized memory views:** Confirm `advance()` is called with a positive delta and
   that the renderer reported a valid artboard/animation. Use `get_last_error()` for detailed GPU
   diagnostics.
+
+## 7. Prototype Control Panel for Rive Streams
+A lightweight browser UI lives under `standalone/rive_frontend/` to help artists and
+TDs experiment with `.riv` payloads before full orchestration wiring is in place.
+Open `index.html` in a local web server (for example, `python -m http.server` from
+the directory) to load animations, tune resolution/frame-rate targets, and draft
+NDI source metadata. The panel exposes a JSON summary block that mirrors the
+`NDIStreamConfig` structure, making it easy to copy/paste into automation scripts
+while the long-term control layer is still under construction.
+
+> [!TIP]
+> The front end is intentionally framework-agnostic. Extend the panels or replace
+the vanilla JavaScript controller when React/Vue/Svelte integration begins. The
+code is heavily commented to highlight the seams that the future control system
+can hook into without rewriting the whole UI.

--- a/standalone/rive_frontend/app.js
+++ b/standalone/rive_frontend/app.js
@@ -1,0 +1,436 @@
+/*
+  ==============================================================================
+
+   This file is part of the YUP library.
+   Copyright (c) 2025 - kunitoki@gmail.com
+
+   YUP is an open source library subject to open-source licensing.
+
+   The code included in this file is provided under the terms of the ISC license
+   http://www.isc.org/downloads/software-support-policy/isc-license. Permission
+   to use, copy, modify, and/or distribute this software for any purpose with or
+   without fee is hereby granted provided that the above copyright notice and
+   this permission notice appear in all copies.
+
+   YUP IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
+   EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
+   DISCLAIMED.
+
+  ==============================================================================
+*/
+
+(() => {
+  "use strict";
+
+  /**
+   * RiveFrontend manages UI interactions for the temporary orchestration panel.
+   * The class deliberately isolates DOM wiring so the eventual integration can
+   * swap in framework-specific bindings without refactoring business logic.
+   */
+  class RiveFrontend {
+    /**
+     * @param {Document} rootDocument The document hosting the UI.
+     */
+    constructor(rootDocument) {
+      this.doc = rootDocument;
+      this.canvas = this.doc.getElementById("rivePreview");
+      this.previewFallback = this.doc.getElementById("previewFallback");
+      this.summaryElement = this.doc.getElementById("sessionSummary");
+      this.artboardGroup = this.doc.getElementById("artboardGroup");
+      this.artboardSelect = this.doc.getElementById("artboardSelect");
+      this.animationSelect = this.doc.getElementById("animationSelect");
+      this.copyButton = this.doc.getElementById("copySummaryButton");
+
+      this.elements = {
+        riveFileInput: this.doc.getElementById("riveFileInput"),
+        widthInput: this.doc.getElementById("widthInput"),
+        heightInput: this.doc.getElementById("heightInput"),
+        frameRateInput: this.doc.getElementById("frameRateInput"),
+        ndiNameInput: this.doc.getElementById("ndiNameInput"),
+        ndiGroupInput: this.doc.getElementById("ndiGroupInput"),
+        notesInput: this.doc.getElementById("notesInput")
+      };
+
+      this.state = {
+        riveFile: null,
+        riveFileInfo: null,
+        artboards: [],
+        selectedArtboard: null,
+        animations: [],
+        selectedAnimation: null,
+        width: Number(this.elements.widthInput.value) || 1920,
+        height: Number(this.elements.heightInput.value) || 1080,
+        frameRate: Number(this.elements.frameRateInput.value) || 60,
+        ndiName: this.elements.ndiNameInput.value.trim(),
+        ndiGroups: this.elements.ndiGroupInput.value.trim(),
+        notes: this.elements.notesInput.value.trim()
+      };
+    }
+
+    /**
+     * Sets up event listeners and renders the initial UI state.
+     */
+    init() {
+      this.elements.riveFileInput.addEventListener("change", (event) => {
+        const [file] = event.target.files ?? [];
+        if (file) {
+          this.handleRiveFileSelected(file).catch((error) => {
+            console.error("Failed to inspect .riv file", error);
+            this.setPreviewFallback(
+              "Unable to load the .riv file. Check the browser console for details."
+            );
+            this.resetRiveMetadata();
+            this.updateSummary();
+          });
+        } else {
+          this.resetRiveMetadata();
+          this.setPreviewFallback("Select a .riv file to initialise the preview.");
+          this.updateSummary();
+        }
+      });
+
+      const numericFields = [
+        ["widthInput", "width"],
+        ["heightInput", "height"],
+        ["frameRateInput", "frameRate"]
+      ];
+
+      numericFields.forEach(([inputKey, stateKey]) => {
+        this.elements[inputKey].addEventListener("input", (event) => {
+          const value = Number(event.target.value);
+          if (!Number.isFinite(value) || value <= 0) {
+            return;
+          }
+          this.state[stateKey] = value;
+          this.updateSummary();
+        });
+      });
+
+      this.elements.ndiNameInput.addEventListener("input", (event) => {
+        this.state.ndiName = event.target.value.trim();
+        this.updateSummary();
+      });
+
+      this.elements.ndiGroupInput.addEventListener("input", (event) => {
+        this.state.ndiGroups = event.target.value.trim();
+        this.updateSummary();
+      });
+
+      this.elements.notesInput.addEventListener("input", (event) => {
+        this.state.notes = event.target.value.trim();
+        this.updateSummary();
+      });
+
+      this.artboardSelect.addEventListener("change", (event) => {
+        this.state.selectedArtboard = event.target.value;
+        this.refreshPreview();
+        this.updateSummary();
+      });
+
+      this.animationSelect.addEventListener("change", (event) => {
+        this.state.selectedAnimation = event.target.value;
+        this.refreshPreview();
+        this.updateSummary();
+      });
+
+      this.copyButton.addEventListener("click", () => {
+        const summaryPayload = this.summaryElement.textContent;
+        if (!summaryPayload) {
+          return;
+        }
+
+        if (navigator.clipboard?.writeText) {
+          navigator.clipboard.writeText(summaryPayload).catch((error) => {
+            console.error("Clipboard copy failed", error);
+          });
+        } else {
+          const helper = this.doc.createElement("textarea");
+          helper.value = summaryPayload;
+          helper.setAttribute("readonly", "readonly");
+          helper.style.position = "absolute";
+          helper.style.left = "-9999px";
+          this.doc.body.appendChild(helper);
+          helper.select();
+          try {
+            this.doc.execCommand("copy");
+          } catch (error) {
+            console.error("Fallback clipboard copy failed", error);
+          } finally {
+            helper.remove();
+          }
+        }
+      });
+
+      this.updateSummary();
+      this.setPreviewFallback("Select a .riv file to initialise the preview.");
+    }
+
+    /**
+     * Handles parsing and preview initialisation when the user selects a .riv file.
+     * @param {File} file The uploaded .riv asset.
+     */
+    async handleRiveFileSelected(file) {
+      this.state.riveFile = file;
+      this.state.riveFileInfo = {
+        name: file.name,
+        sizeBytes: file.size,
+        lastModified: file.lastModified
+      };
+
+      this.setPreviewFallback("Loading Rive runtime …");
+
+      await this.populateRiveMetadata(file);
+      this.updateSummary();
+      await this.refreshPreview();
+    }
+
+    /**
+     * Populates artboard and animation drop-downs when possible. Falls back to
+     * minimal metadata when the runtime is unavailable (for example, while
+     * working offline or when the CDN is blocked).
+     * @param {File} file The uploaded .riv file.
+     */
+    async populateRiveMetadata(file) {
+      if (typeof window.rive === "undefined" || !window.rive?.RiveFile) {
+        this.resetRiveMetadata();
+        this.setPreviewFallback(
+          "Rive runtime unavailable. Preview is disabled, but settings can still be edited."
+        );
+        return;
+      }
+
+      const buffer = await file.arrayBuffer();
+      const uint8Buffer = new Uint8Array(buffer);
+
+      let riveFile;
+      if (typeof window.rive.RiveFile === "function" && window.rive.RiveFile.fromRuntimeBuffer) {
+        riveFile = await window.rive.RiveFile.fromRuntimeBuffer(uint8Buffer);
+      } else if (typeof window.rive.load === "function") {
+        // Older runtimes expose a convenience helper.
+        riveFile = await window.rive.load({ buffer: uint8Buffer });
+      } else {
+        this.resetRiveMetadata();
+        this.setPreviewFallback(
+          "Rive runtime detected but unsupported. Preview disabled; metadata reset."
+        );
+        return;
+      }
+
+      const artboards = Array.isArray(riveFile?.artboardNames)
+        ? riveFile.artboardNames
+        : typeof riveFile?.artboardCount === "function"
+        ? this.extractArtboardNames(riveFile)
+        : [];
+
+      this.state.artboards = artboards;
+      this.state.selectedArtboard = artboards[0] ?? null;
+
+      const animations = this.extractAnimationNames(riveFile, this.state.selectedArtboard);
+      this.state.animations = animations;
+      this.state.selectedAnimation = animations[0] ?? null;
+
+      this.populateSelect(this.artboardSelect, artboards);
+      this.populateSelect(this.animationSelect, animations);
+
+      const shouldShowMetadata = artboards.length > 0 || animations.length > 0;
+      this.artboardGroup.hidden = !shouldShowMetadata;
+
+      if (!shouldShowMetadata) {
+        this.setPreviewFallback(
+          "File loaded, but artboard/animation metadata was not exposed by the runtime."
+        );
+      }
+    }
+
+    /**
+     * Extracts artboard names when the runtime exposes only count/index APIs.
+     * @param {object} riveFile The parsed Rive file instance.
+     * @returns {string[]} Artboard names, if discoverable.
+     */
+    extractArtboardNames(riveFile) {
+      if (typeof riveFile.artboardCount !== "function" || typeof riveFile.artboardByIndex !== "function") {
+        return [];
+      }
+      const names = [];
+      const count = riveFile.artboardCount();
+      for (let index = 0; index < count; index += 1) {
+        try {
+          const artboard = riveFile.artboardByIndex(index);
+          if (artboard?.name) {
+            names.push(artboard.name);
+          }
+        } catch (error) {
+          console.warn("Failed to resolve artboard name", error);
+        }
+      }
+      return names;
+    }
+
+    /**
+     * Extracts animation and state machine names from a parsed Rive file.
+     * @param {object} riveFile The parsed file instance.
+     * @param {string|null} artboardName The selected artboard name.
+     * @returns {string[]} Available animation/state machine names.
+     */
+    extractAnimationNames(riveFile, artboardName) {
+      if (!artboardName || typeof riveFile.artboardByName !== "function") {
+        return [];
+      }
+      try {
+        const artboard = riveFile.artboardByName(artboardName);
+        if (!artboard) {
+          return [];
+        }
+
+        const animationNames = [];
+        if (typeof artboard.animationCount === "function" && typeof artboard.animationByIndex === "function") {
+          const count = artboard.animationCount();
+          for (let index = 0; index < count; index += 1) {
+            const animation = artboard.animationByIndex(index);
+            if (animation?.name) {
+              animationNames.push(animation.name);
+            }
+          }
+        }
+
+        if (typeof artboard.stateMachineCount === "function" && typeof artboard.stateMachineByIndex === "function") {
+          const count = artboard.stateMachineCount();
+          for (let index = 0; index < count; index += 1) {
+            const stateMachine = artboard.stateMachineByIndex(index);
+            if (stateMachine?.name) {
+              animationNames.push(stateMachine.name);
+            }
+          }
+        }
+        return animationNames;
+      } catch (error) {
+        console.warn("Failed to extract animation metadata", error);
+        return [];
+      }
+    }
+
+    /**
+     * Populates a <select> element with the given entries.
+     * @param {HTMLSelectElement} select The select element to update.
+     * @param {string[]} entries The options to render.
+     */
+    populateSelect(select, entries) {
+      select.innerHTML = "";
+      entries.forEach((entry) => {
+        const option = this.doc.createElement("option");
+        option.value = entry;
+        option.textContent = entry;
+        select.appendChild(option);
+      });
+    }
+
+    /**
+     * Re-renders the JSON summary block to keep downstream systems aligned with
+     * the current UI state.
+     */
+    updateSummary() {
+      const payload = {
+        ndi: {
+          name: this.state.ndiName || "Unnamed Source",
+          groups: this.state.ndiGroups ? this.state.ndiGroups.split(",").map((group) => group.trim()).filter(Boolean) : [],
+          notes: this.state.notes || undefined
+        },
+        renderer: {
+          width: this.state.width,
+          height: this.state.height,
+          frameRate: this.state.frameRate,
+          artboard: this.state.selectedArtboard || undefined,
+          animation: this.state.selectedAnimation || undefined
+        },
+        riveFile: this.state.riveFileInfo
+      };
+
+      this.summaryElement.textContent = JSON.stringify(payload, null, 2);
+    }
+
+    /**
+     * Re-initialises the preview canvas if the runtime is available.
+     */
+    async refreshPreview() {
+      if (!this.state.riveFile || typeof window.rive === "undefined" || !window.rive?.Rive) {
+        this.setPreviewFallback(
+          this.state.riveFile
+            ? "Preview unavailable. The browser could not load the Rive runtime."
+            : "Select a .riv file to initialise the preview."
+        );
+        return;
+      }
+
+      const arrayBuffer = await this.state.riveFile.arrayBuffer();
+      const uint8Buffer = new Uint8Array(arrayBuffer);
+      const artboard = this.state.selectedArtboard || undefined;
+      const animation = this.state.selectedAnimation ? [this.state.selectedAnimation] : undefined;
+
+      if (this.riveInstance) {
+        this.riveInstance.cleanup();
+        this.riveInstance = null;
+      }
+
+      try {
+        this.riveInstance = new window.rive.Rive({
+          buffer: uint8Buffer,
+          canvas: this.canvas,
+          autoplay: true,
+          artboard,
+          animations: animation,
+          stateMachines: animation,
+          fit: window.rive.Fit.CONTAIN,
+          onLoad: () => {
+            this.riveInstance.resizeDrawingSurfaceToCanvas();
+            this.setPreviewFallback("");
+          },
+          onError: (error) => {
+            console.error("Rive runtime reported an error", error);
+            this.setPreviewFallback("Failed to render preview. Check the browser console for details.");
+          }
+        });
+      } catch (error) {
+        console.error("Unable to start Rive preview", error);
+        this.setPreviewFallback("Failed to render preview. Check the browser console for details.");
+      }
+    }
+
+    /**
+     * Clears runtime-specific metadata when the user deselects a file.
+     */
+    resetRiveMetadata() {
+      this.state.riveFile = null;
+      this.state.riveFileInfo = null;
+      this.state.artboards = [];
+      this.state.selectedArtboard = null;
+      this.state.animations = [];
+      this.state.selectedAnimation = null;
+      this.populateSelect(this.artboardSelect, []);
+      this.populateSelect(this.animationSelect, []);
+      this.artboardGroup.hidden = true;
+      if (this.riveInstance) {
+        this.riveInstance.cleanup();
+        this.riveInstance = null;
+      }
+    }
+
+    /**
+     * Updates the preview fallback text and toggles visibility.
+     * @param {string} message The fallback message to display.
+     */
+    setPreviewFallback(message) {
+      if (!message) {
+        this.previewFallback.hidden = true;
+        this.previewFallback.textContent = "";
+        return;
+      }
+      this.previewFallback.hidden = false;
+      this.previewFallback.textContent = message;
+    }
+  }
+
+  window.addEventListener("DOMContentLoaded", () => {
+    const frontend = new RiveFrontend(document);
+    frontend.init();
+  });
+})();

--- a/standalone/rive_frontend/index.html
+++ b/standalone/rive_frontend/index.html
@@ -1,0 +1,124 @@
+<!--
+  ==============================================================================
+
+   This file is part of the YUP library.
+   Copyright (c) 2025 - kunitoki@gmail.com
+
+   YUP is an open source library subject to open-source licensing.
+
+   The code included in this file is provided under the terms of the ISC license
+   http://www.isc.org/downloads/software-support-policy/isc-license. Permission
+   to use, copy, modify, and/or distribute this software for any purpose with or
+   without fee is hereby granted provided that the above copyright notice and
+   this permission notice appear in all copies.
+
+   YUP IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
+   EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
+   DISCLAIMED.
+
+  ==============================================================================
+-->
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>YUP Rive NDI Control Panel</title>
+    <link rel="stylesheet" href="styles.css" />
+    <script defer src="https://unpkg.com/@rive-app/canvas@2.17.0"></script>
+    <script defer src="app.js"></script>
+  </head>
+  <body>
+    <header class="app-header">
+      <h1>YUP Rive → NDI Control Panel</h1>
+      <p class="subtitle">
+        Temporary front end for loading <code>.riv</code> files and preparing NDI stream settings.
+        Designed for rapid iteration and future integration.
+      </p>
+    </header>
+
+    <main class="app-layout">
+      <section class="panel" aria-labelledby="file-panel-title">
+        <div class="panel-header">
+          <h2 id="file-panel-title">Rive Asset</h2>
+          <p>Choose an animation and optional artboard for preview.</p>
+        </div>
+        <div class="panel-body">
+          <label class="field">
+            <span class="field-label">Rive file</span>
+            <input id="riveFileInput" type="file" accept=".riv" />
+          </label>
+          <div class="field-group" id="artboardGroup" hidden>
+            <label class="field">
+              <span class="field-label">Artboard</span>
+              <select id="artboardSelect"></select>
+            </label>
+            <label class="field">
+              <span class="field-label">Animation / State Machine</span>
+              <select id="animationSelect"></select>
+            </label>
+          </div>
+          <div class="preview" aria-live="polite">
+            <canvas id="rivePreview" width="640" height="360"></canvas>
+            <p id="previewFallback" class="preview-fallback" hidden>
+              Select a <code>.riv</code> file to initialise the preview.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section class="panel" aria-labelledby="stream-settings-title">
+        <div class="panel-header">
+          <h2 id="stream-settings-title">Stream Settings</h2>
+          <p>Tune output parameters that will be forwarded to the NDI pipeline.</p>
+        </div>
+        <div class="panel-body">
+          <div class="field-row">
+            <label class="field">
+              <span class="field-label">Output width (px)</span>
+              <input id="widthInput" type="number" min="64" step="1" value="1920" />
+            </label>
+            <label class="field">
+              <span class="field-label">Output height (px)</span>
+              <input id="heightInput" type="number" min="64" step="1" value="1080" />
+            </label>
+          </div>
+          <label class="field">
+            <span class="field-label">Frame rate (fps)</span>
+            <input id="frameRateInput" type="number" min="1" step="0.01" value="60" />
+          </label>
+          <label class="field">
+            <span class="field-label">NDI source name</span>
+            <input id="ndiNameInput" type="text" maxlength="128" value="StudioA" />
+          </label>
+          <label class="field">
+            <span class="field-label">NDI group(s)</span>
+            <input id="ndiGroupInput" type="text" placeholder="Optional comma-separated list" />
+          </label>
+          <label class="field">
+            <span class="field-label">Notes</span>
+            <textarea id="notesInput" rows="3" placeholder="Document decisions or TODOs for this stream."></textarea>
+          </label>
+        </div>
+      </section>
+
+      <section class="panel" aria-labelledby="session-summary-title">
+        <div class="panel-header">
+          <h2 id="session-summary-title">Session Summary</h2>
+          <p>Review the configuration payload that will be forwarded downstream.</p>
+        </div>
+        <div class="panel-body">
+          <pre id="sessionSummary" class="summary" aria-live="polite"></pre>
+          <button id="copySummaryButton" type="button" class="primary-button">Copy summary JSON</button>
+          <p class="summary-hint">Use this payload to seed orchestrator APIs or save presets.</p>
+        </div>
+      </section>
+    </main>
+
+    <footer class="app-footer">
+      <p>
+        This UI is intentionally lightweight. Extend the panels or add routing logic as the orchestration layer evolves.
+      </p>
+    </footer>
+  </body>
+</html>

--- a/standalone/rive_frontend/styles.css
+++ b/standalone/rive_frontend/styles.css
@@ -1,0 +1,248 @@
+/*
+  ==============================================================================
+
+   This file is part of the YUP library.
+   Copyright (c) 2025 - kunitoki@gmail.com
+
+   YUP is an open source library subject to open-source licensing.
+
+   The code included in this file is provided under the terms of the ISC license
+   http://www.isc.org/downloads/software-support-policy/isc-license. Permission
+   to use, copy, modify, and/or distribute this software for any purpose with or
+   without fee is hereby granted provided that the above copyright notice and
+   this permission notice appear in all copies.
+
+   YUP IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
+   EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
+   DISCLAIMED.
+
+  ==============================================================================
+*/
+
+:root {
+  color-scheme: light dark;
+  --surface: rgba(255, 255, 255, 0.9);
+  --surface-dark: rgba(18, 18, 18, 0.85);
+  --text: #1c1c1c;
+  --text-dark: #f3f3f3;
+  --accent: #005f73;
+  --accent-foreground: #ffffff;
+  --border: rgba(0, 0, 0, 0.08);
+  --border-dark: rgba(255, 255, 255, 0.12);
+  --radius: 12px;
+  --shadow: 0 18px 24px rgba(0, 0, 0, 0.08);
+  font-size: 16px;
+}
+
+body {
+  margin: 0;
+  font-family: "Segoe UI", "Helvetica Neue", system-ui, -apple-system, sans-serif;
+  background: linear-gradient(135deg, #f3f4f6, #d4e8ff);
+  color: var(--text);
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  line-height: 1.5;
+}
+
+@media (prefers-color-scheme: dark) {
+  body {
+    background: linear-gradient(135deg, #0f172a, #1e293b);
+    color: var(--text-dark);
+  }
+
+  .panel,
+  header,
+  footer {
+    background-color: var(--surface-dark);
+    border-color: var(--border-dark);
+  }
+
+  .panel {
+    box-shadow: 0 18px 28px rgba(0, 0, 0, 0.45);
+  }
+}
+
+.app-header,
+.app-footer {
+  margin: 0 auto;
+  width: min(1100px, 92vw);
+  padding: 24px;
+  background-color: var(--surface);
+  border-radius: var(--radius);
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow);
+}
+
+.app-header h1 {
+  margin-bottom: 8px;
+  font-weight: 700;
+}
+
+.subtitle {
+  margin: 0;
+  max-width: 60ch;
+  color: rgba(0, 0, 0, 0.65);
+}
+
+@media (prefers-color-scheme: dark) {
+  .subtitle {
+    color: rgba(255, 255, 255, 0.7);
+  }
+}
+
+.app-layout {
+  flex: 1;
+  margin: 24px auto;
+  width: min(1100px, 92vw);
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 24px;
+}
+
+.panel {
+  display: flex;
+  flex-direction: column;
+  background-color: var(--surface);
+  border-radius: var(--radius);
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow);
+  overflow: hidden;
+}
+
+.panel-header {
+  padding: 20px 24px 0 24px;
+}
+
+.panel-header h2 {
+  margin: 0 0 8px 0;
+  font-size: 1.25rem;
+}
+
+.panel-header p {
+  margin: 0;
+  color: rgba(0, 0, 0, 0.55);
+}
+
+.panel-body {
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.field,
+.field-row {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.field-row {
+  flex-direction: row;
+  gap: 16px;
+}
+
+.field-row .field {
+  flex: 1;
+}
+
+.field-label {
+  font-size: 0.875rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+input,
+select,
+textarea {
+  font: inherit;
+  padding: 10px 12px;
+  border-radius: 8px;
+  border: 1px solid rgba(0, 0, 0, 0.15);
+  background-color: rgba(255, 255, 255, 0.92);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+input:focus,
+select:focus,
+textarea:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(0, 95, 115, 0.2);
+}
+
+textarea {
+  resize: vertical;
+}
+
+.preview {
+  position: relative;
+  border-radius: 10px;
+  border: 1px dashed rgba(0, 0, 0, 0.2);
+  background: rgba(0, 0, 0, 0.02);
+  min-height: 180px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.preview canvas {
+  max-width: 100%;
+  border-radius: 10px;
+}
+
+.preview-fallback {
+  position: absolute;
+  margin: 0;
+  font-size: 0.95rem;
+  color: rgba(0, 0, 0, 0.6);
+  text-align: center;
+}
+
+.summary {
+  background: rgba(15, 23, 42, 0.85);
+  color: #f8fafc;
+  padding: 18px;
+  border-radius: 10px;
+  min-height: 160px;
+  overflow: auto;
+}
+
+.primary-button {
+  align-self: flex-start;
+  border: none;
+  border-radius: 8px;
+  padding: 12px 18px;
+  background: linear-gradient(135deg, #0ea5e9, #2563eb);
+  color: white;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.primary-button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 8px 18px rgba(37, 99, 235, 0.35);
+}
+
+.summary-hint {
+  margin: 0;
+  color: rgba(0, 0, 0, 0.55);
+}
+
+.app-footer {
+  margin-bottom: 36px;
+}
+
+@media (max-width: 720px) {
+  .field-row {
+    flex-direction: column;
+  }
+
+  .panel-header,
+  .panel-body {
+    padding: 20px;
+  }
+}


### PR DESCRIPTION
## Summary
- add a standalone browser-based control panel for loading Rive assets and editing NDI stream settings
- implement modular JavaScript logic and styling that keep the panel extensible for future orchestration work
- document how to launch the prototype front end inside the Rive to NDI guide

## Testing
- manual: served the panel locally with `python -m http.server 8000` and opened it in a browser


------
https://chatgpt.com/codex/tasks/task_e_68d63834f7cc8329b8db3756462a9662