### PR TITLE
Fix cyndilib async video send

### DIFF
--- a/docs/rive_ndi_overview.md
+++ b/docs/rive_ndi_overview.md
@@ -11,7 +11,7 @@ configurable staging-buffer ring to balance latency against throughput.
 - **Python binding surface:** The `yup_rive_renderer` module mirrors the renderer API, including
 zero-copy frame views that the orchestrator can forward directly to NDI senders.
 - **NDI orchestration:** The `yup_ndi` package manages multiple renderers, maintains timing metadata,
-forwards frames to `cyndilib` senders, and provides runtime control hooks.
+forwards frames to `cyndilib` senders, and provides runtime control hooks. When asynchronous delivery is enabled, the orchestrator now emits frames through `cyndilib.write_video_async()` so each buffer is sent exactly once while keeping CPU usage low.
 - **Production-ready failure handling:** The renderer now validates requested dimensions, falls back to
   WARP when hardware devices refuse to initialise, and propagates descriptive errors (including
   HRESULT codes) through the Python bindings and orchestrator so operators see actionable diagnostics.

--- a/python/tests/test_yup_ndi/test_orchestrator.py
+++ b/python/tests/test_yup_ndi/test_orchestrator.py
@@ -685,6 +685,10 @@ def test_default_factories_wire_renderer_and_sender (monkeypatch: pytest.MonkeyP
         def write_video (self, buffer: memoryview) -> None:
             self.video_payloads.append(buffer)
 
+        def write_video_async (self, buffer: memoryview) -> None:
+            self.sent_async = True
+            self.video_payloads.append(buffer)
+
         def send_video_async (self) -> None:
             self.sent_async = True
 

--- a/python/yup_ndi/orchestrator.py
+++ b/python/yup_ndi/orchestrator.py
@@ -549,13 +549,14 @@ class _CyndiLibSenderHandle:
 
         contiguous = buffer.cast("B")
         if self._use_async:
-            if hasattr(self._sender, "write_video_async"):
-                self._sender.write_video_async(contiguous)
-            else:
-                self._sender.write_video(contiguous)
-                self._sender.send_video_async()
-        else:
-            self._sender.write_video(contiguous)
+            write_async = getattr(self._sender, "write_video_async", None)
+            if callable(write_async):
+                write_async(contiguous)
+                return
+
+            _logger.debug("Sender missing write_video_async; falling back to synchronous send")
+
+        self._sender.write_video(contiguous)
 
     def apply_metadata (self, metadata: Mapping[str, Mapping[str, Any]]) -> None:
         if not metadata:


### PR DESCRIPTION
## Summary
- route async NDI sends through `cyndilib.write_video_async()` and log when falling back to synchronous writes
- document the orchestration change in the pipeline overview
- extend the orchestrator test stub to cover the async send path

## Testing
- pytest python/tests/test_yup_ndi/test_orchestrator.py

------
https://chatgpt.com/codex/tasks/task_e_68d851fd88808329a2715e2076c4c5e1