### PR TITLE
Fix asynchronous NDI send path to avoid duplicate frames

### DIFF
--- a/docs/Rive to NDI Guide.md
+++ b/docs/Rive to NDI Guide.md
@@ -109,6 +109,13 @@ interfaces above the orchestrator.
 > non-zero denominator—validation errors are raised eagerly so misconfigured streams fail fast.
 
 > [!IMPORTANT]
+> When `NDIStreamConfig.use_async_send` is left at its default of `True`, the orchestrator feeds frame
+> payloads to :meth:`cyndilib.Sender.write_video_async`. This keeps uploads non-blocking without the
+> redundant `write_video()` + `send_video_async()` combination that sent each frame twice. Older
+> `cyndilib` builds that lack `write_video_async` automatically fall back to the synchronous
+> `write_video()` path.
+
+> [!IMPORTANT]
 > When you configure a `frame_rate`, use `NDIOrchestrator.set_stream_start_time()` (or pass the
 > optional `start_time` keyword to `add_stream()`) to anchor the deterministic 100 ns timeline before
 > sending the first frame. This prevents drift when pumping fractional rates such as 30000/1001. The

--- a/python/tests/test_yup_ndi/test_orchestrator.py
+++ b/python/tests/test_yup_ndi/test_orchestrator.py
@@ -670,6 +670,7 @@ def test_default_factories_wire_renderer_and_sender (monkeypatch: pytest.MonkeyP
             self.video_frame: Optional[StubVideoFrame] = None
             self.open_called = False
             self.video_payloads: list[memoryview] = []
+            self.async_video_payloads: list[memoryview] = []
             self.sent_async = False
             self.sent_sync = False
             self.metadata: list[tuple[str, Mapping[str, Any]]] = []
@@ -684,6 +685,11 @@ def test_default_factories_wire_renderer_and_sender (monkeypatch: pytest.MonkeyP
 
         def write_video (self, buffer: memoryview) -> None:
             self.video_payloads.append(buffer)
+
+        def write_video_async (self, buffer: memoryview) -> None:
+            self.video_payloads.append(buffer)
+            self.async_video_payloads.append(buffer)
+            self.sent_async = True
 
         def send_video_async (self) -> None:
             self.sent_async = True
@@ -748,6 +754,7 @@ def test_default_factories_wire_renderer_and_sender (monkeypatch: pytest.MonkeyP
     assert isinstance(payload, memoryview)
     assert bytes(payload) == bytes(range(16))
     assert sender.sent_async is True
+    assert sender.async_video_payloads == [payload]
     assert sender.sent_sync is False
 
     assert sender.metadata == [("ndi", {"title": "demo"})]

--- a/python/yup_ndi/orchestrator.py
+++ b/python/yup_ndi/orchestrator.py
@@ -549,11 +549,14 @@ class _CyndiLibSenderHandle:
 
         contiguous = buffer.cast("B")
         if self._use_async:
-            if hasattr(self._sender, "write_video_async"):
-                self._sender.write_video_async(contiguous)
+            write_video_async = getattr(self._sender, "write_video_async", None)
+            if callable(write_video_async):
+                write_video_async(contiguous)
             else:
+                _logger.debug(
+                    "cyndilib sender does not expose write_video_async; falling back to synchronous send"
+                )
                 self._sender.write_video(contiguous)
-                self._sender.send_video_async()
         else:
             self._sender.write_video(contiguous)
 


### PR DESCRIPTION
## Summary
- ensure the cyndilib sender only issues one video upload per frame and gracefully fall back when async helpers are unavailable
- update the NDI orchestrator tests to assert the async write path and retain payload tracking
- document the expected cyndilib async behaviour in the Rive → NDI pipeline guide

## Testing
- pytest python/tests/test_yup_ndi/test_orchestrator.py -k orchestrator -q

------
https://chatgpt.com/codex/tasks/task_e_68d851fd88808329a2715e2076c4c5e1