### PR TITLE
Fix async NDI frame send path

### DIFF
--- a/docs/Rive to NDI Guide.md
+++ b/docs/Rive to NDI Guide.md
@@ -119,6 +119,10 @@ mirroring the direct Python API. Set it to a higher value when streams are consu
 when a few extra milliseconds of buffering keeps throughput stable. Invalid or missing entries fall
 back to the default of `1` and raise descriptive errors when misconfigured.
 
+`use_async_send` controls how frames are handed to :mod:`cyndilib`. When enabled (the default) the
+orchestrator now issues a single `write_video_async()` call per frame so the payload is queued exactly
+once. Disable it if you need synchronous behaviour—`write_video()` is used in that case.
+
 ### Command-line runner and control surfaces
 The package now ships with a convenience CLI so you can spin up a stream without writing a custom
 script. Invoke it with `python -m yup_ndi` and supply the renderer dimensions plus the `.riv` file:

--- a/python/tests/test_yup_ndi/test_orchestrator.py
+++ b/python/tests/test_yup_ndi/test_orchestrator.py
@@ -685,6 +685,10 @@ def test_default_factories_wire_renderer_and_sender (monkeypatch: pytest.MonkeyP
         def write_video (self, buffer: memoryview) -> None:
             self.video_payloads.append(buffer)
 
+        def write_video_async (self, buffer: memoryview) -> None:
+            self.video_payloads.append(buffer)
+            self.sent_async = True
+
         def send_video_async (self) -> None:
             self.sent_async = True
 

--- a/python/yup_ndi/orchestrator.py
+++ b/python/yup_ndi/orchestrator.py
@@ -548,12 +548,8 @@ class _CyndiLibSenderHandle:
             _logger.debug("Unable to set NDI timestamp on video frame")
 
         contiguous = buffer.cast("B")
-        if self._use_async:
-            if hasattr(self._sender, "write_video_async"):
-                self._sender.write_video_async(contiguous)
-            else:
-                self._sender.write_video(contiguous)
-                self._sender.send_video_async()
+        if self._use_async and hasattr(self._sender, "write_video_async"):
+            self._sender.write_video_async(contiguous)
         else:
             self._sender.write_video(contiguous)
 


### PR DESCRIPTION
## Summary
- ensure the cyndilib sender wrapper only issues a single frame upload, preferring `write_video_async`
- document how `use_async_send` now uses `write_video_async` and when to fall back to synchronous sending
- align the orchestrator unit test stubs with the new async write behaviour

## Testing
- pytest python/tests/test_yup_ndi -q

------
https://chatgpt.com/codex/tasks/task_e_68d851fd88808329a2715e2076c4c5e1