### PR TITLE
Fix cyndilib async send usage

### DIFF
--- a/docs/rive_ndi_overview.md
+++ b/docs/rive_ndi_overview.md
@@ -36,11 +36,13 @@ frames as bytes or `memoryview` objects without copying when possible. Callers c
 reused.
 3. **Publish over NDI:** `yup_ndi.NDIOrchestrator` instantiates renderers, maps timestamps into the
 100 ns NDI domain, forwards frames to `cyndilib` senders, and applies metadata/control commands. The
-stream timeline now uses a fixed-point accumulator, avoiding per-frame `Fraction` arithmetic while
-keeping deterministic cadence for fractional frame rates. Use `set_stream_start_time()` (or the
-optional `start_time` argument on `add_stream()`) to prime the deterministic timestamp anchor so
-frames align to a consistent monotonic origin. The CLI frame pump wires this up automatically before
-emitting the first frame.
+sender adapter now routes asynchronous pipelines through `cyndilib.Sender.write_video_async()` when
+available so each frame is transferred exactly once, falling back to the synchronous
+`write_video()` call when async support is absent. The stream timeline now uses a fixed-point
+accumulator, avoiding per-frame `Fraction` arithmetic while keeping deterministic cadence for
+fractional frame rates. Use `set_stream_start_time()` (or the optional `start_time` argument on
+`add_stream()`) to prime the deterministic timestamp anchor so frames align to a consistent
+monotonic origin. The CLI frame pump wires this up automatically before emitting the first frame.
 
 The orchestrator also exposes a `renderer_options` dictionary so deployments can request deeper staging
 queues when buffering bursts or multiple consumers is preferable to the lowest possible latency.

--- a/python/tests/test_yup_ndi/test_orchestrator.py
+++ b/python/tests/test_yup_ndi/test_orchestrator.py
@@ -685,6 +685,10 @@ def test_default_factories_wire_renderer_and_sender (monkeypatch: pytest.MonkeyP
         def write_video (self, buffer: memoryview) -> None:
             self.video_payloads.append(buffer)
 
+        def write_video_async (self, buffer: memoryview) -> None:
+            self.sent_async = True
+            self.video_payloads.append(buffer)
+
         def send_video_async (self) -> None:
             self.sent_async = True
 

--- a/python/yup_ndi/orchestrator.py
+++ b/python/yup_ndi/orchestrator.py
@@ -549,11 +549,14 @@ class _CyndiLibSenderHandle:
 
         contiguous = buffer.cast("B")
         if self._use_async:
-            if hasattr(self._sender, "write_video_async"):
-                self._sender.write_video_async(contiguous)
+            write_video_async = getattr(self._sender, "write_video_async", None)
+            if callable(write_video_async):
+                write_video_async(contiguous)
             else:
+                _logger.debug(
+                    "write_video_async not available on sender; falling back to synchronous write"
+                )
                 self._sender.write_video(contiguous)
-                self._sender.send_video_async()
         else:
             self._sender.write_video(contiguous)
 


### PR DESCRIPTION
## Summary
- route asynchronous NDI frame delivery through `write_video_async` so frames are only sent once
- document the sender behaviour in the Rive → NDI overview
- update orchestrator tests with a stub sender that exposes the new async API

## Testing
- pytest python/tests/test_yup_ndi/test_orchestrator.py

------
https://chatgpt.com/codex/tasks/task_e_68d851fd88808329a2715e2076c4c5e1