### PR TITLE
Add coverage for cyndilib async fallback

### DIFF
--- a/build_analysis_report.md
+++ b/build_analysis_report.md
@@ -36,12 +36,22 @@ The code was corrected to use the appropriate `cyndilib` function based on the `
 # Corrected code
 contiguous = buffer.cast("B")
 if self._use_async:
-    self._sender.write_video_async(contiguous)
+    write_video_async = getattr(self._sender, "write_video_async", None)
+    if callable(write_video_async):
+        write_video_async(contiguous)
+    else:
+        _logger.debug(
+            "cyndilib sender does not expose write_video_async; falling back to synchronous send"
+        )
+        self._sender.write_video(contiguous)
 else:
     self._sender.write_video(contiguous)
 ```
 
-This change has been made and is ready for submission.
+This change has been made and now gracefully falls back to the synchronous
+`write_video()` path when older `cyndilib` builds do not expose
+`write_video_async`, ensuring the frame is still transmitted without the
+duplicate send behaviour that triggered this investigation.
 
 ## 3. C++ Build System Analysis and Blockers
 

--- a/python/tests/test_yup_ndi/test_orchestrator.py
+++ b/python/tests/test_yup_ndi/test_orchestrator.py
@@ -21,6 +21,8 @@
 
 from __future__ import annotations
 
+import logging
+
 from dataclasses import dataclass
 from fractions import Fraction
 from types import SimpleNamespace
@@ -763,6 +765,54 @@ def test_default_factories_wire_renderer_and_sender (monkeypatch: pytest.MonkeyP
 
     assert renderer.stopped is True
     assert sender.closed is True
+
+
+def test_cyndilib_sender_handle_falls_back_when_async_write_missing (caplog: pytest.LogCaptureFixture) -> None:
+    class StubVideoFrame:
+        def __init__ (self) -> None:
+            self.resolutions: list[tuple[int, int]] = []
+            self.strides: list[int] = []
+            self.ptr = SimpleNamespace(timestamp=None)
+
+        def set_resolution (self, width: int, height: int) -> None:
+            self.resolutions.append((width, height))
+
+        def _set_line_stride (self, stride: int) -> None:
+            self.strides.append(stride)
+
+    class StubSender:
+        def __init__ (self) -> None:
+            self.video_payloads: list[bytes] = []
+            self.sent_async = False
+            self.sent_sync = False
+
+        def write_video (self, buffer: memoryview) -> None:
+            self.video_payloads.append(bytes(buffer))
+
+        def send_video_async (self) -> None:
+            self.sent_async = True
+
+        def send_video (self) -> None:
+            self.sent_sync = True
+
+    sender = StubSender()
+    frame = StubVideoFrame()
+    handle = orchestrator_module._CyndiLibSenderHandle(sender, frame, use_async=True)
+
+    payload = memoryview(bytes(range(16)))
+
+    with caplog.at_level(logging.DEBUG):
+        handle.send(payload, width=2, height=2, stride=8, timestamp=42)
+
+    assert frame.resolutions[-1] == (2, 2)
+    assert frame.strides[-1] == 8
+    assert frame.ptr.timestamp == 42
+
+    assert sender.video_payloads == [bytes(payload)]
+    assert sender.sent_async is False
+    assert sender.sent_sync is False
+
+    assert "does not expose write_video_async" in caplog.text
 
 
 def test_fractional_frame_rate_produces_evenly_spaced_timestamps () -> None:


### PR DESCRIPTION
## Summary
- document the chosen async send fix in the build analysis report, including the synchronous fallback path
- add a regression test that exercises the _CyndiLibSenderHandle fallback when write_video_async is unavailable

## Testing
- pytest python/tests/test_yup_ndi/test_orchestrator.py

------
https://chatgpt.com/codex/tasks/task_e_68d85520deb883298db9b356a3c5cf97