### PR TITLE
Fix module targets to build as static libraries

### DIFF
--- a/cmake/yup_modules.cmake
+++ b/cmake/yup_modules.cmake
@@ -182,17 +182,34 @@ function (_yup_module_setup_target module_name
                                    module_frameworks
                                    module_dependencies
                                    module_arc_enabled)
+    get_target_property (module_target_type ${module_name} TYPE)
+    if (NOT module_target_type)
+        _yup_message (FATAL_ERROR "Target ${module_name} has not been created")
+    endif()
+
+    if (module_target_type STREQUAL "INTERFACE_LIBRARY")
+        set (module_sources_scope INTERFACE)
+        set (module_compile_scope INTERFACE)
+        set (module_link_scope INTERFACE)
+        set (module_features_scope INTERFACE)
+    else()
+        set (module_sources_scope PRIVATE)
+        set (module_compile_scope PUBLIC)
+        set (module_link_scope PUBLIC)
+        set (module_features_scope PUBLIC)
+    endif()
+
     if (YUP_PLATFORM_MSFT)
         list (APPEND module_defines NOMINMAX=1 WIN32_LEAN_AND_MEAN=1)
         list (APPEND module_options /bigobj)
     endif()
 
-    target_sources (${module_name} INTERFACE ${module_sources})
+    target_sources (${module_name} ${module_sources_scope} ${module_sources})
 
     if (module_cpp_standard)
-        target_compile_features (${module_name} INTERFACE cxx_std_${module_cpp_standard})
+        target_compile_features (${module_name} ${module_features_scope} cxx_std_${module_cpp_standard})
     else()
-        target_compile_features (${module_name} INTERFACE cxx_std_17)
+        target_compile_features (${module_name} ${module_features_scope} cxx_std_17)
     endif()
 
     set_target_properties (${module_name} PROPERTIES
@@ -206,27 +223,27 @@ function (_yup_module_setup_target module_name
             XCODE_GENERATE_SCHEME OFF)
     endif()
 
-    target_compile_options (${module_name} INTERFACE
+    target_compile_options (${module_name} ${module_compile_scope}
         ${module_options})
 
-    target_compile_definitions (${module_name} INTERFACE
+    target_compile_definitions (${module_name} ${module_compile_scope}
         $<IF:$<CONFIG:Debug>,DEBUG=1,NDEBUG=1>
         YUP_MODULE_AVAILABLE_${module_name}=1
         YUP_GLOBAL_MODULE_SETTINGS_INCLUDED=1
         ${module_defines})
 
-    target_include_directories (${module_name} INTERFACE
+    target_include_directories (${module_name} ${module_link_scope}
         ${module_include_paths})
 
-    target_link_directories (${module_name} INTERFACE
+    target_link_directories (${module_name} ${module_link_scope}
         ${module_libs_paths})
 
-    target_link_libraries (${module_name} INTERFACE
+    target_link_libraries (${module_name} ${module_link_scope}
         ${module_libs}
         ${module_frameworks}
         ${module_dependencies})
 
-    target_link_options (${module_name} INTERFACE
+    target_link_options (${module_name} ${module_link_scope}
         ${module_link_options})
 
     # Add coverage support if enabled
@@ -343,7 +360,7 @@ function (yup_add_module module_path modules_definitions module_group)
     endif()
 
     # ==== Add module as library
-    add_library (${module_name} INTERFACE)
+    add_library (${module_name} STATIC)
     set_target_properties (${module_name} PROPERTIES FOLDER "${module_group}")
 
     # ==== Parse module declaration string

--- a/docs/YUP Module Format.md
+++ b/docs/YUP Module Format.md
@@ -6,6 +6,11 @@ Their structure is designed to make it as simple as possible for modules to be a
 
 Each module may have dependencies on other modules, but should be otherwise self-contained.
 
+When building with the bundled CMake tooling, every module is compiled into its own static
+library. Linking a module from another target will therefore reuse the prebuilt object files
+while inheriting the module's include directories, compile definitions, and external library
+dependencies.
+
 ## File structure
 
 Each module lives inside a folder whose name is the same as the name of the module. The YUP convention for naming modules is lower-case with underscores, e.g.


### PR DESCRIPTION
## Summary
- teach `_yup_module_setup_target` to respect the concrete target type and apply compile settings with PUBLIC scopes for real libraries
- switch module targets generated by `yup_add_module` to static libraries so dependencies propagate correctly
- document that the bundled CMake flow now builds every module as a static library

## Testing
- cmake -S . -B build -DYUP_ENABLE_AUDIO_MODULES=OFF

------
https://chatgpt.com/codex/tasks/task_e_68d858200ed483298425b216f87bf8f6