### PR TITLE
Refactor module build targets into static libraries

### DIFF
--- a/build_analysis_report.md
+++ b/build_analysis_report.md
@@ -55,7 +55,8 @@ duplicate send behaviour that triggered this investigation.
 
 ## 3. C++ Build System Analysis and Blockers
 
-Verifying the Python fix was prevented by a cascade of C++ compilation errors. The following is a summary of the investigation and findings.
+Verifying the Python fix initially surfaced a cascade of C++ compilation errors. The investigation below documents those
+failures and the remediation now in place.
 
 ### Initial Build Failures & Fixes
 
@@ -75,17 +76,24 @@ This led to a cascade of "header not found" errors, such as:
 *   `yup_core/containers/yup_MemoryBlock.h: No such file or directory` in `yup_gui`.
 *   `#error This binding file requires adding the yup_events module in the project` in `yup_python`.
 
-### Attempts to Fix the Build System
+### CMake Module System Remediation
 
-Several attempts were made to correct the CMake build system:
+The build now succeeds in configuring the module graph after refactoring the bespoke module helper to emit normal static
+libraries:
 
-1.  **Changed `INTERFACE` to `STATIC`**: In `cmake/yup_modules.cmake`, all module library definitions were changed from `INTERFACE` to `STATIC`.
-2.  **Corrected Target Properties**: The properties for these new `STATIC` libraries were updated, making source files `PRIVATE` and all other properties (`PUBLIC`) to ensure correct dependency propagation.
-3.  **Fixed Missing Dependencies**: Explicit `dependencies` were added to the module headers for `rive_decoders` and `yup_python`.
-4.  **Corrected Include Paths**: Incorrect relative include paths in `yup_gui.cpp` and `yup_ArtboardFile.cpp` were fixed to be relative to the `modules` directory.
-5.  **Declared `SDL2` Dependency**: The `yup_gui` module header was updated to explicitly declare its dependency on `SDL2::SDL2` for all desktop platforms.
+1.  **Converted Module Targets to `STATIC`**: Every module defined via `_yup_module_setup_target` is materialised as a static
+    library, ensuring that each translation unit is compiled exactly once and eliminating multiple-definition failures.
+2.  **Propagated Usage Requirements**: Compile features, options, definitions, include paths, link directories, link options and
+    dependent libraries are now exposed with `PUBLIC` scope so consumers inherit the correct build settings automatically.
+3.  **Enabled Position Independent Code**: Modules are compiled with `POSITION_INDEPENDENT_CODE` to keep the resulting archives
+    linkable into the project’s shared libraries (such as the pybind11 extension) on POSIX platforms.
+4.  **Retained Module Metadata**: The existing declaration parsing and dependency wiring remains intact, so higher-level CMake
+    code does not need to change its module definitions.
 
-Despite these significant corrections, the build still fails with dependency-related errors, indicating that the build system's issues are complex and deeply rooted.
+With these adjustments, the configuration phase now correctly resolves module dependencies without duplicating compilation. On
+Linux environments without the SDL2 development package installed, the build now progresses until the `yup_gui` target attempts
+to include `SDL2/SDL.h`; installing the dependency (or building on Windows, where the Direct3D implementation is primary) is
+still required to complete the native build.
 
 ## 4. Recommendations
 

--- a/cmake/yup_modules.cmake
+++ b/cmake/yup_modules.cmake
@@ -187,18 +187,21 @@ function (_yup_module_setup_target module_name
         list (APPEND module_options /bigobj)
     endif()
 
-    target_sources (${module_name} INTERFACE ${module_sources})
+    if (module_sources)
+        target_sources (${module_name} PRIVATE ${module_sources})
+    endif()
 
     if (module_cpp_standard)
-        target_compile_features (${module_name} INTERFACE cxx_std_${module_cpp_standard})
+        target_compile_features (${module_name} PUBLIC cxx_std_${module_cpp_standard})
     else()
-        target_compile_features (${module_name} INTERFACE cxx_std_17)
+        target_compile_features (${module_name} PUBLIC cxx_std_17)
     endif()
 
     set_target_properties (${module_name} PROPERTIES
         CXX_EXTENSIONS OFF
         CXX_VISIBILITY_PRESET hidden
-        VISIBILITY_INLINES_HIDDEN ON)
+        VISIBILITY_INLINES_HIDDEN ON
+        POSITION_INDEPENDENT_CODE ON)
 
     if (YUP_PLATFORM_APPLE)
         set_target_properties (${module_name} PROPERTIES
@@ -206,27 +209,27 @@ function (_yup_module_setup_target module_name
             XCODE_GENERATE_SCHEME OFF)
     endif()
 
-    target_compile_options (${module_name} INTERFACE
+    target_compile_options (${module_name} PUBLIC
         ${module_options})
 
-    target_compile_definitions (${module_name} INTERFACE
+    target_compile_definitions (${module_name} PUBLIC
         $<IF:$<CONFIG:Debug>,DEBUG=1,NDEBUG=1>
         YUP_MODULE_AVAILABLE_${module_name}=1
         YUP_GLOBAL_MODULE_SETTINGS_INCLUDED=1
         ${module_defines})
 
-    target_include_directories (${module_name} INTERFACE
+    target_include_directories (${module_name} PUBLIC
         ${module_include_paths})
 
-    target_link_directories (${module_name} INTERFACE
+    target_link_directories (${module_name} PUBLIC
         ${module_libs_paths})
 
-    target_link_libraries (${module_name} INTERFACE
+    target_link_libraries (${module_name} PUBLIC
         ${module_libs}
         ${module_frameworks}
         ${module_dependencies})
 
-    target_link_options (${module_name} INTERFACE
+    target_link_options (${module_name} PUBLIC
         ${module_link_options})
 
     # Add coverage support if enabled
@@ -261,7 +264,7 @@ function (_yup_module_setup_plugin_client target_name plugin_client_target folde
         _yup_message (FATAL_ERROR "Invalid plugin type: ${plugin_type}. Must be either 'vst3', 'clap' or 'standalone'")
     endif()
 
-    add_library (${custom_target_name} INTERFACE)
+    add_library (${custom_target_name} STATIC)
     set_target_properties (${custom_target_name} PROPERTIES FOLDER "${folder_name}")
 
     get_target_property (module_path ${plugin_client_target} YUP_MODULE_PATH)
@@ -343,7 +346,7 @@ function (yup_add_module module_path modules_definitions module_group)
     endif()
 
     # ==== Add module as library
-    add_library (${module_name} INTERFACE)
+    add_library (${module_name} STATIC)
     set_target_properties (${module_name} PROPERTIES FOLDER "${module_group}")
 
     # ==== Parse module declaration string

--- a/modules/yup_python/yup_python.h
+++ b/modules/yup_python/yup_python.h
@@ -30,7 +30,7 @@
   website:            https://github.com/kunitoki/yup
   license:            ISC
 
-  dependencies:       yup_core
+  dependencies:       yup_core yup_events yup_graphics yup_gui
   needsPython:        true
 
  END_YUP_MODULE_DECLARATION

--- a/thirdparty/rive_decoders/rive_decoders.h
+++ b/thirdparty/rive_decoders/rive_decoders.h
@@ -32,6 +32,7 @@
     website:            https://github.com/rive-app/rive-runtime
     license:            MIT
 
+    dependencies:       rive
     searchpaths:        include
     appleFrameworks:    ImageIO
     enableARC:          1


### PR DESCRIPTION
## Summary
- refactor the bespoke module helper to emit static libraries with proper PUBLIC usage requirements and PIC
- declare the required module dependencies for the python bindings and rive decoders modules
- document the remediation and remaining SDL2 prerequisite in the build analysis report

## Testing
- cmake -S . -B build -DYUP_ENABLE_AUDIO_MODULES=0
- cmake --build build --target yup_python -- -j$(nproc) *(fails: missing SDL2 development headers in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d858200ed483298425b216f87bf8f6