### PR TITLE
Consolidate cyndilib async fallback handling

### DIFF
--- a/build_analysis_report.md
+++ b/build_analysis_report.md
@@ -34,24 +34,33 @@ The code was corrected to use the appropriate `cyndilib` function based on the `
 
 ```python
 # Corrected code
-contiguous = buffer.cast("B")
+self._write_video_async: Optional[Callable[[memoryview], Any]] = None
 if self._use_async:
-    write_video_async = getattr(self._sender, "write_video_async", None)
-    if callable(write_video_async):
-        write_video_async(contiguous)
-    else:
-        _logger.debug(
-            "cyndilib sender does not expose write_video_async; falling back to synchronous send"
-        )
-        self._sender.write_video(contiguous)
-else:
-    self._sender.write_video(contiguous)
+    candidate = getattr(self._sender, "write_video_async", None)
+    if callable(candidate):
+        self._write_video_async = candidate
+
+contiguous = buffer.cast("B")
+if self._use_async and self._write_video_async is not None:
+    self._write_video_async(contiguous)
+    return
+
+if self._use_async and not self._missing_async_logged:
+    _logger.debug(
+        "cyndilib sender does not expose write_video_async; falling back to synchronous send"
+    )
+    self._missing_async_logged = True
+
+self._sender.write_video(contiguous)
 ```
 
 This change has been made and now gracefully falls back to the synchronous
 `write_video()` path when older `cyndilib` builds do not expose
 `write_video_async`, ensuring the frame is still transmitted without the
-duplicate send behaviour that triggered this investigation.
+duplicate send behaviour that triggered this investigation. The
+consolidated solution caches the `write_video_async` lookup and only logs
+the fallback once, preventing repeated introspection work and debug-log
+spam when long-running streams rely on synchronous sending.
 
 ## 3. C++ Build System Analysis and Blockers
 

--- a/docs/Rive to NDI Guide.md
+++ b/docs/Rive to NDI Guide.md
@@ -113,7 +113,9 @@ interfaces above the orchestrator.
 > payloads to :meth:`cyndilib.Sender.write_video_async`. This keeps uploads non-blocking without the
 > redundant `write_video()` + `send_video_async()` combination that sent each frame twice. Older
 > `cyndilib` builds that lack `write_video_async` automatically fall back to the synchronous
-> `write_video()` path.
+> `write_video()` path. The sender handle caches whether asynchronous uploads are supported and emits
+> a single debug log the first time it falls back, so operators can confirm which code path is active
+> without flooding log files during long sessions.
 
 > [!IMPORTANT]
 > When you configure a `frame_rate`, use `NDIOrchestrator.set_stream_start_time()` (or pass the

--- a/python/tests/test_yup_ndi/test_orchestrator.py
+++ b/python/tests/test_yup_ndi/test_orchestrator.py
@@ -767,36 +767,38 @@ def test_default_factories_wire_renderer_and_sender (monkeypatch: pytest.MonkeyP
     assert sender.closed is True
 
 
+class _MissingAsyncVideoFrame:
+    def __init__ (self) -> None:
+        self.resolutions: list[tuple[int, int]] = []
+        self.strides: list[int] = []
+        self.ptr = SimpleNamespace(timestamp=None)
+
+    def set_resolution (self, width: int, height: int) -> None:
+        self.resolutions.append((width, height))
+
+    def _set_line_stride (self, stride: int) -> None:
+        self.strides.append(stride)
+
+
+class _MissingAsyncSender:
+    def __init__ (self) -> None:
+        self.video_payloads: list[bytes] = []
+        self.sent_async = False
+        self.sent_sync = False
+
+    def write_video (self, buffer: memoryview) -> None:
+        self.video_payloads.append(bytes(buffer))
+
+    def send_video_async (self) -> None:
+        self.sent_async = True
+
+    def send_video (self) -> None:
+        self.sent_sync = True
+
+
 def test_cyndilib_sender_handle_falls_back_when_async_write_missing (caplog: pytest.LogCaptureFixture) -> None:
-    class StubVideoFrame:
-        def __init__ (self) -> None:
-            self.resolutions: list[tuple[int, int]] = []
-            self.strides: list[int] = []
-            self.ptr = SimpleNamespace(timestamp=None)
-
-        def set_resolution (self, width: int, height: int) -> None:
-            self.resolutions.append((width, height))
-
-        def _set_line_stride (self, stride: int) -> None:
-            self.strides.append(stride)
-
-    class StubSender:
-        def __init__ (self) -> None:
-            self.video_payloads: list[bytes] = []
-            self.sent_async = False
-            self.sent_sync = False
-
-        def write_video (self, buffer: memoryview) -> None:
-            self.video_payloads.append(bytes(buffer))
-
-        def send_video_async (self) -> None:
-            self.sent_async = True
-
-        def send_video (self) -> None:
-            self.sent_sync = True
-
-    sender = StubSender()
-    frame = StubVideoFrame()
+    sender = _MissingAsyncSender()
+    frame = _MissingAsyncVideoFrame()
     handle = orchestrator_module._CyndiLibSenderHandle(sender, frame, use_async=True)
 
     payload = memoryview(bytes(range(16)))
@@ -813,6 +815,27 @@ def test_cyndilib_sender_handle_falls_back_when_async_write_missing (caplog: pyt
     assert sender.sent_sync is False
 
     assert "does not expose write_video_async" in caplog.text
+
+
+def test_cyndilib_sender_handle_logs_once_when_async_write_missing (caplog: pytest.LogCaptureFixture) -> None:
+    sender = _MissingAsyncSender()
+    frame = _MissingAsyncVideoFrame()
+    handle = orchestrator_module._CyndiLibSenderHandle(sender, frame, use_async=True)
+
+    payload = memoryview(bytes(range(16)))
+    caplog.clear()
+    with caplog.at_level(logging.DEBUG):
+        handle.send(payload, width=2, height=2, stride=8, timestamp=123)
+        handle.send(payload, width=2, height=2, stride=8, timestamp=456)
+
+    fallback_messages = [
+        record for record in caplog.records
+        if "does not expose write_video_async" in record.getMessage()
+    ]
+    assert len(fallback_messages) == 1
+    assert sender.video_payloads == [bytes(payload), bytes(payload)]
+    assert sender.sent_async is False
+    assert sender.sent_sync is False
 
 
 def test_fractional_frame_rate_produces_evenly_spaced_timestamps () -> None:

--- a/python/yup_ndi/orchestrator.py
+++ b/python/yup_ndi/orchestrator.py
@@ -527,6 +527,12 @@ class _CyndiLibSenderHandle:
         self._video_frame = video_frame
         self._use_async = use_async
         self._last_connection_count = -1
+        self._write_video_async: Optional[Callable[[memoryview], Any]] = None
+        self._missing_async_logged = False
+        if self._use_async:
+            candidate = getattr(self._sender, "write_video_async", None)
+            if callable(candidate):
+                self._write_video_async = candidate
 
     def send (self, buffer: memoryview, width: int, height: int, stride: int, timestamp: int) -> None:
         try:
@@ -548,17 +554,17 @@ class _CyndiLibSenderHandle:
             _logger.debug("Unable to set NDI timestamp on video frame")
 
         contiguous = buffer.cast("B")
-        if self._use_async:
-            write_video_async = getattr(self._sender, "write_video_async", None)
-            if callable(write_video_async):
-                write_video_async(contiguous)
-            else:
-                _logger.debug(
-                    "cyndilib sender does not expose write_video_async; falling back to synchronous send"
-                )
-                self._sender.write_video(contiguous)
-        else:
-            self._sender.write_video(contiguous)
+        if self._use_async and self._write_video_async is not None:
+            self._write_video_async(contiguous)
+            return
+
+        if self._use_async and not self._missing_async_logged:
+            _logger.debug(
+                "cyndilib sender does not expose write_video_async; falling back to synchronous send"
+            )
+            self._missing_async_logged = True
+
+        self._sender.write_video(contiguous)
 
     def apply_metadata (self, metadata: Mapping[str, Mapping[str, Any]]) -> None:
         if not metadata:


### PR DESCRIPTION
## Summary
- cache the cyndilib async upload callable inside `_CyndiLibSenderHandle` and emit the fallback log only once when asynchronous sends are unavailable
- expand the orchestrator tests to cover the cached fallback path and guard against repeated log spam
- document the consolidated behaviour in both the build analysis report and the Rive to NDI guide

## Testing
- pytest python/tests/test_yup_ndi/test_orchestrator.py::test_cyndilib_sender_handle_falls_back_when_async_write_missing python/tests/test_yup_ndi/test_orchestrator.py::test_cyndilib_sender_handle_logs_once_when_async_write_missing


------
https://chatgpt.com/codex/tasks/task_e_68d9419385888329b89c8000830e5c79