### PR TITLE
Fix memoryview format for renderer frames

### DIFF
--- a/docs/Rive to NDI Guide.md
+++ b/docs/Rive to NDI Guide.md
@@ -65,9 +65,11 @@ frame = renderer.acquire_frame_view()  # zero-copy BGRA memoryview
 the value (for example, when feeding multiple consumers) to smooth out bursts at the cost of a few
 frames of additional latency. Leave it at the default of `1` when you need lowest-latency updates.
 
-`acquire_frame_view()` returns a read-only `memoryview` that can be cast to a flat byte buffer or into
-`(height, width, 4)` NumPy arrays. `get_frame_bytes()` remains available when a defensive copy is
-needed.
+`acquire_frame_view()` returns a read-only `memoryview` that advertises a `"B"` (unsigned byte)
+format.  This allows `memoryview.cast("B")` and NumPy consumers to recognise the buffer as
+packed BGRA data and preserves zero-copy behaviour when moving between Python versions.  The
+view can be cast to a flat byte buffer or reshaped into `(height, width, 4)` arrays as needed.
+`get_frame_bytes()` remains available when a defensive copy is required.
 
 ## 4. Publish Frames Over NDI
 The `yup_ndi` package orchestrates renderers and senders. It accepts factories for dependency

--- a/python/src/yup_rive_renderer.cpp
+++ b/python/src/yup_rive_renderer.cpp
@@ -77,6 +77,7 @@ namespace
             return py::memoryview::from_buffer (
                 &dummy,
                 sizeof (uint8),
+                "B",
                 std::vector<py::ssize_t> { 0 },
                 std::vector<py::ssize_t> { 1 },
                 true);
@@ -97,6 +98,7 @@ namespace
         return py::memoryview::from_buffer (
             data,
             sizeof (uint8),
+            "B",
             std::vector<py::ssize_t> { height, width, 4 },
             std::vector<py::ssize_t> { stride, 4, 1 },
             true,


### PR DESCRIPTION
## Summary
- update the pybind11 memoryview construction to pass the unsigned-byte format string for renderer frames
- document the exposed memoryview format in the Rive to NDI guide to clarify zero-copy consumption

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d9833eaaec8329b495dad1ac945dd3