### PR TITLE
Ensure rive decoders pull image back ends transitively

### DIFF
--- a/docs/Building Standalone.md
+++ b/docs/Building Standalone.md
@@ -114,10 +114,7 @@ yup_standalone_app (
     INITIAL_MEMORY 268435456  # 256MB initial memory
     MODULES
         yup_audio_devices
-        yup_gui
-        libpng
-        libwebp
-        libjpeg)
+        yup_gui)
 
 # Add source files
 file (GLOB sources "${CMAKE_CURRENT_LIST_DIR}/*.cpp")
@@ -131,6 +128,10 @@ if (NOT YUP_TARGET_ANDROID)
     target_sources (${target_name} PRIVATE ${resources})
 endif()
 ```
+
+> **Note:** The raster image back-ends (`libpng`, `libwebp`, and `libjpeg` when available) are now pulled in automatically via
+> the `rive_decoders` module that `yup_graphics` depends on. You only need to add those modules explicitly if your application
+> consumes them outside of the graphics stack.
 
 ## Application Resources
 
@@ -159,9 +160,6 @@ yup_standalone_app (
     MODULES
         yup_audio_devices
         yup_gui
-        libpng
-        libwebp
-        libjpeg
         ${target_name}_binary_data) # << add this
 ```
 

--- a/thirdparty/rive_decoders/rive_decoders.h
+++ b/thirdparty/rive_decoders/rive_decoders.h
@@ -28,7 +28,7 @@
     vendor:             rive
     version:            1.0
     name:               Rive Decoders.
-    description:        The Rive Decoders is a companion library for ratser image decoding.
+    description:        The Rive Decoders is a companion library for raster image decoding back-ends (libpng, libwebp, libjpeg).
     website:            https://github.com/rive-app/rive-runtime
     license:            MIT
 


### PR DESCRIPTION
## Summary
- document that the rive decoders module now carries libpng/libwebp/libjpeg as transitive dependencies for yup_graphics consumers
- clean up the rive decoders module description to mention the raster back-end libraries
- update the standalone build guide to note that the image decoders no longer need to be listed manually in module declarations

## Testing
- cmake -S . -B build -DYUP_BUILD_TESTS=ON -DYUP_BUILD_EXAMPLES=OFF -DYUP_ENABLE_AUDIO_MODULES=OFF
- cmake --build build --target yup_graphics


------
https://chatgpt.com/codex/tasks/task_e_68d9910ab1fc83298a5a9e2a560a9067