### PR TITLE
Enforce desktop Windows-only builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,10 @@ endif()
 project (yup VERSION ${yup_version})
 set_property (GLOBAL PROPERTY USE_FOLDERS ON)
 
+if (NOT WIN32 OR CMAKE_SYSTEM_NAME MATCHES "WindowsStore")
+    _yup_message (FATAL_ERROR "This branch only supports desktop Windows builds. Detected CMake system name: ${CMAKE_SYSTEM_NAME}.")
+endif()
+
 # Options
 option (YUP_TARGET_ANDROID "Target Android project" OFF)
 option (YUP_TARGET_ANDROID_BUILD_GRADLE "When building for Android, build the gradle infrastructure" OFF)

--- a/cmake/yup.cmake
+++ b/cmake/yup.cmake
@@ -71,6 +71,10 @@ function (_yup_setup_platform)
 
     endif()
 
+    if (NOT platform STREQUAL "windows")
+        _yup_message (FATAL_ERROR "Non-Windows builds are intentionally unsupported on this branch (detected: ${platform}).")
+    endif()
+
     _yup_message (STATUS "Setting up for ${platform} platform")
     _yup_message (STATUS "Running on cmake ${CMAKE_VERSION}")
 

--- a/docs/Windows Build and Packaging.md
+++ b/docs/Windows Build and Packaging.md
@@ -5,6 +5,13 @@ packaging the Python bindings, and validating the NDI orchestration path on Wind
 The steps assume Visual Studio 2022 (or another C++20-compatible compiler), Python 3.11+,
 and the Windows 10 or 11 SDK are installed.
 
+> [!IMPORTANT]
+> This branch intentionally supports **desktop Windows builds only**. The CMake tooling now
+> hard-errors when configured on macOS, Linux, UWP, or other non-Windows targets so that the
+> engineering effort stays focused on the Direct3D 11 → Python → NDI pipeline. If you need
+> multiplatform support, use an earlier commit before the Windows-only guard was introduced
+> or track the upstream repository for future cross-platform updates.
+
 ## 0. Automated bootstrap (optional)
 
 When you want a turnkey setup, run the PowerShell helper from a VS 2022 developer


### PR DESCRIPTION
## Summary
- fail configuration immediately when the detected platform is not desktop Windows
- add a top-level CMake guard so the restriction is visible during configuration
- document the Windows-only focus in the build and packaging guide

## Testing
- not run (documentation and configuration updates only)

------
https://chatgpt.com/codex/tasks/task_e_68d9a683a22883298331a869cb99dc8b