### PR TITLE
Disable non-Windows workflows on Windows-focused branch

### DIFF
--- a/.github/workflows/build_android.yml
+++ b/.github/workflows/build_android.yml
@@ -1,26 +1,12 @@
 name: Android
 
+# NOTE: Windows is the only supported CI target on this branch.
+# Non-Windows workflows are retained for historical reference and disabled by default.
+
 # See https://medium.com/@dcostalloyd90/automating-android-builds-with-github-actions-a-step-by-step-guide-2a02a54f59cd
 
 on:
-  push:
-    paths:
-      - "CMakeLists.txt"
-      - "**/workflows/build_android.yml"
-      - "**/cmake/**"
-      - "**/examples/**"
-      - "**/modules/**"
-      - "**/tests/**"
-      - "**/thirdparty/**"
-      - "!**/native/*_apple.*"
-      - "!**/native/*_emscripten.*"
-      - "!**/native/*_ios.*"
-      - "!**/native/*_linux.*"
-      - "!**/native/*_mac.*"
-      - "!**/native/*_wasm.*"
-      - "!**/native/*_windows.*"
-    branches:
-      - "**"
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/build_ios.yml
+++ b/.github/workflows/build_ios.yml
@@ -1,24 +1,9 @@
 name: iOS
 
+# NOTE: Windows is the only supported CI target on this branch.
+# Non-Windows workflows are retained for historical reference and disabled by default.
 on:
-  push:
-    paths:
-      - "CMakeLists.txt"
-      - "**/workflows/build_ios.yml"
-      - "**/cmake/**"
-      - "**/modules/**"
-      - "**/tests/**"
-      - "**/thirdparty/**"
-      - "!**/native/generated/**"
-      - "!**/native/java*/**"
-      - "!**/native/*_android.*"
-      - "!**/native/*_emscripten.*"
-      - "!**/native/*_linux.*"
-      - "!**/native/*_mac.*"
-      - "!**/native/*_wasm.*"
-      - "!**/native/*_windows.*"
-    branches:
-      - "**"
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -1,27 +1,9 @@
 name: Linux
 
+# NOTE: Windows is the only supported CI target on this branch.
+# Non-Windows workflows are retained for historical reference and disabled by default.
 on:
-  push:
-    paths:
-      - "CMakeLists.txt"
-      - "**/workflows/build_linux.yml"
-      - "**/cmake/**"
-      - "**/examples/**"
-      - "**/modules/**"
-      - "**/python/**"
-      - "**/tests/**"
-      - "**/thirdparty/**"
-      - "!**/native/generated/**"
-      - "!**/native/java*/**"
-      - "!**/native/*_android.*"
-      - "!**/native/*_apple.*"
-      - "!**/native/*_emscripten.*"
-      - "!**/native/*_ios.*"
-      - "!**/native/*_mac.*"
-      - "!**/native/*_wasm.*"
-      - "!**/native/*_windows.*"
-    branches:
-      - "**"
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/build_macos.yml
+++ b/.github/workflows/build_macos.yml
@@ -1,26 +1,9 @@
 name: MacOS
 
+# NOTE: Windows is the only supported CI target on this branch.
+# Non-Windows workflows are retained for historical reference and disabled by default.
 on:
-  push:
-    paths:
-      - "CMakeLists.txt"
-      - "**/workflows/build_macos.yml"
-      - "**/cmake/**"
-      - "**/examples/**"
-      - "**/modules/**"
-      - "**/python/**"
-      - "**/tests/**"
-      - "**/thirdparty/**"
-      - "!**/native/generated/**"
-      - "!**/native/java*/**"
-      - "!**/native/*_android.*"
-      - "!**/native/*_emscripten.*"
-      - "!**/native/*_linux.*"
-      - "!**/native/*_ios.*"
-      - "!**/native/*_wasm.*"
-      - "!**/native/*_windows.*"
-    branches:
-      - "**"
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/build_wasm.yml
+++ b/.github/workflows/build_wasm.yml
@@ -1,25 +1,9 @@
 name: Wasm
 
+# NOTE: Windows is the only supported CI target on this branch.
+# Non-Windows workflows are retained for historical reference and disabled by default.
 on:
-  push:
-    paths:
-      - "CMakeLists.txt"
-      - "**/workflows/build_wasm.yml"
-      - "**/cmake/**"
-      - "**/examples/**"
-      - "**/modules/**"
-      - "**/tests/**"
-      - "**/thirdparty/**"
-      - "!**/native/generated/**"
-      - "!**/native/java*/**"
-      - "!**/native/*_android.*"
-      - "!**/native/*_apple.*"
-      - "!**/native/*_linux.*"
-      - "!**/native/*_ios.*"
-      - "!**/native/*_mac.*"
-      - "!**/native/*_windows.*"
-    branches:
-      - "**"
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/python_linux.yml
+++ b/.github/workflows/python_linux.yml
@@ -1,25 +1,9 @@
 name: Linux Python
 
+# NOTE: Windows is the only supported CI target on this branch.
+# Non-Windows workflows are retained for historical reference and disabled by default.
 on:
-  push:
-    paths:
-      - "CMakeLists.txt"
-      - "**/workflows/python_linux.yml"
-      - "**/cmake/**"
-      - "**/modules/**"
-      - "**/thirdparty/**"
-      - "**/python/**"
-      - "!**/native/generated/**"
-      - "!**/native/java*/**"
-      - "!**/native/*_android.*"
-      - "!**/native/*_apple.*"
-      - "!**/native/*_emscripten.*"
-      - "!**/native/*_ios.*"
-      - "!**/native/*_mac.*"
-      - "!**/native/*_wasm.*"
-      - "!**/native/*_windows.*"
-    branches:
-      - "**"
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/python_macos.yml
+++ b/.github/workflows/python_macos.yml
@@ -1,24 +1,9 @@
 name: MacOS Python
 
+# NOTE: Windows is the only supported CI target on this branch.
+# Non-Windows workflows are retained for historical reference and disabled by default.
 on:
-  push:
-    paths:
-      - "CMakeLists.txt"
-      - "**/workflows/python_macos.yml"
-      - "**/cmake/**"
-      - "**/modules/**"
-      - "**/thirdparty/**"
-      - "**/python/**"
-      - "!**/native/generated/**"
-      - "!**/native/java*/**"
-      - "!**/native/*_android.*"
-      - "!**/native/*_emscripten.*"
-      - "!**/native/*_linux.*"
-      - "!**/native/*_ios.*"
-      - "!**/native/*_wasm.*"
-      - "!**/native/*_windows.*"
-    branches:
-      - "**"
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ switching, and metadata updates.
 - **Tested workflow:** GoogleTest and `pytest` suites validate renderer semantics, binding behaviour,
 and orchestrator integration without requiring native NDI libraries during development.
 
+### Continuous Integration
+Only the Windows GitHub Actions workflow runs automatically on this branch. Linux, macOS, Android,
+iOS, and wasm workflows remain in the repository for historical reference but have been converted to
+manual `workflow_dispatch` jobs so that non-Windows runs do not generate noise during Windows-focused
+development. Trigger them manually from the Actions tab if you need to verify a legacy configuration.
+
 ## Repository Layout
 | Path | Description |
 | ---- | ----------- |


### PR DESCRIPTION
## Summary
- disable Linux, macOS, Android, iOS, and wasm GitHub Actions by converting their triggers to manual dispatch and annotating each workflow
- update the README to note that non-Windows workflows are intentionally disabled during the Windows-focused effort

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9a831efe4832981c07368972c7cab