### PR TITLE
Expand Windows smoke tests to cover CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,8 @@ Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass
 The script provisions a `.venv` virtual environment, installs build requirements,
 configures the Visual Studio solution with audio modules disabled, compiles the
 selected configuration (Release by default), builds and reinstalls the Python
-wheel, and finishes by exercising the renderer/NDI smoke tests. Useful flags
+wheel, and finishes by exercising the renderer/NDI smoke tests covering the
+binding, orchestrator, and CLI layers. Useful flags
 include:
 
 - `-Configuration Debug` – build the Debug configuration instead of Release.
@@ -99,7 +100,7 @@ directory instead.
 > documentation-only environments can execute the remaining Python checks.
 
 ### Run Renderer ↔ NDI Smoke Tests
-Targeted smoke tests verify zero-copy frame access and orchestrator behaviour:
+Targeted smoke tests verify zero-copy frame access, orchestrator behaviour, and CLI parsing:
 ```powershell
 just python_smoke
 ```

--- a/docs/Windows Build and Packaging.md
+++ b/docs/Windows Build and Packaging.md
@@ -26,8 +26,9 @@ The script creates (or reuses) `.venv`, installs build/test dependencies,
 configures the Visual Studio solution with audio modules disabled, builds the
 specified configuration (Release by default), produces the Python wheel,
 reinstalls it into the virtual environment, and runs the renderer/NDI smoke
-tests. Use `-Configuration Debug`, `-SkipWheel`, `-SkipSmokeTests`, or
-`-InstallCyndilib` to adjust the workflow.
+tests that cover the binding, orchestrator, and CLI layers. Use
+`-Configuration Debug`, `-SkipWheel`, `-SkipSmokeTests`, or `-InstallCyndilib`
+to adjust the workflow.
 
 ## 1. Prepare the environment
 
@@ -108,9 +109,10 @@ tests. Use `-Configuration Debug`, `-SkipWheel`, `-SkipSmokeTests`, or
 
 ## 4. Run renderer and NDI smoke tests
 
-The `python/tests/test_yup_rive_renderer` and `python/tests/test_yup_ndi` suites validate
-that the bindings expose zero-copy frame access and that the orchestrator can marshal
-frames into NDI senders. A convenient `just` recipe is available:
+The focused smoke set runs `python/tests/test_yup_rive_renderer/test_binding_interface.py`,
+`python/tests/test_yup_ndi/test_orchestrator.py`, and
+`python/tests/test_yup_ndi/test_cli.py` to validate zero-copy frame access, orchestrator
+NDI marshalling, and CLI parsing. A convenient `just` recipe is available:
 
 ```powershell
 just python_smoke

--- a/justfile
+++ b/justfile
@@ -115,3 +115,4 @@ python_test *TEST_OPTS:
 python_smoke:
   @just python_test tests/test_yup_rive_renderer/test_binding_interface.py -q
   @just python_test tests/test_yup_ndi/test_orchestrator.py -q
+  @just python_test tests/test_yup_ndi/test_cli.py -q

--- a/tools/install_windows.ps1
+++ b/tools/install_windows.ps1
@@ -238,10 +238,11 @@ try {
     & $venvPython -m pip install --force-reinstall $wheel.FullName
 
     if (-not $SkipSmokeTests) {
-        Write-Section "Running renderer and NDI smoke tests"
+        Write-Section "Running renderer, orchestrator, and CLI smoke tests"
         & $venvPython -m pytest -q `
             tests/test_yup_rive_renderer/test_binding_interface.py `
-            tests/test_yup_ndi/test_orchestrator.py
+            tests/test_yup_ndi/test_orchestrator.py `
+            tests/test_yup_ndi/test_cli.py
     } else {
         Write-Host "Smoke tests skipped." -ForegroundColor Yellow
     }


### PR DESCRIPTION
## Summary
- extend the Windows bootstrap script to run the CLI smoke test alongside the renderer and orchestrator checks
- mirror the added CLI smoke coverage in the `python_smoke` just recipe used by local workflows
- update the README and Windows build guide so the documented behaviour matches the refreshed smoke test set

## Testing
- not run (PowerShell automation cannot be exercised in this Linux environment)


------
https://chatgpt.com/codex/tasks/task_e_68da1121f2208329beb43fd0ad7a4a90