### PR TITLE
docs: refresh Windows build playbooks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,8 +24,8 @@ You are extending YUP to deliver a Windows-focused pipeline that renders Rive (`
   - `README.md` – quickstart build/test recipes and API overview.
   - `docs/rive_ndi_overview.md` – Windows-focused walkthrough of the renderer → NDI flow.
   - `docs/Rive to NDI Guide.md` – detailed step-by-step orchestration and tooling guide.
-  - `docs/Windows Build and Packaging.md` – MSVC toolchain, packaging, and release notes.
-  - `docs/BUILD_WINDOWS.md` – legacy but still-referenced Windows build primer.
+  - `docs/Windows Build and Packaging.md` – authoritative MSVC toolchain, packaging, and troubleshooting workflow. Keep the quickstart aligned with `tools/install_windows.ps1`.
+  - `docs/BUILD_WINDOWS.md` – concise Windows onboarding primer that mirrors the packaging doc and highlights helper recipes.
   - `docs/Building Plugins.md` and `docs/Building Standalone.md` – ancillary build targets.
   - `docs/YUP Module Format.md` – module metadata expectations.
   - `standalone/rive_frontend/` – temporary browser control panel; keep copy updates mirrored in the minified builds under `docs/demos/` and ensure the generated payload schema matches `python/yup_ndi/orchestrator.py`.

--- a/README.md
+++ b/README.md
@@ -69,9 +69,11 @@ include:
 
 ### Clone the Repository
 ```powershell
-git clone https://github.com/kunitoki/yup.git
+git clone --recurse-submodules https://github.com/kunitoki/yup.git
 cd yup
 ```
+
+> **Already cloned?** Pull in submodules with `git submodule update --init --recursive` before configuring CMake.
 
 ### Configure & Build Native Targets (Visual Studio)
 Generate a project that focuses on the renderer, bindings, and tests:

--- a/docs/BUILD_WINDOWS.md
+++ b/docs/BUILD_WINDOWS.md
@@ -1,6 +1,6 @@
 # Windows Build Guide
 
-This guide walks through building the YUP renderer, running its test suite, and producing the Python extension on a **fresh Windows 11 installation**. The steps below assume you are starting from an empty machine and want a repeatable process that any contributor can follow.
+This guide walks through building the YUP renderer, running its test suite, and producing the Python extension on a **fresh Windows 11 installation**. The steps below assume you are starting from an empty machine and want a repeatable process that any contributor can follow. Use it alongside `docs/Windows Build and Packaging.md`—that document expands on smoke tests, packaging, and troubleshooting.
 
 ## 1. Install Required Software
 
@@ -14,18 +14,26 @@ This guide walks through building the YUP renderer, running its test suite, and 
      - C++ ATL for latest v143 build tools (optional but recommended)
 2. **CMake 3.28 or newer**
    - Visual Studio bundles an older version. Install the latest release from [cmake.org/download](https://cmake.org/download/), and choose the option to add CMake to the system PATH for all users.
-3. **Python 3.11 (or newer 3.10+)**
+3. **Ninja 1.11 or newer**
+   - Download the Windows zip from the [Ninja releases page](https://github.com/ninja-build/ninja/releases), extract `ninja.exe` somewhere on `PATH`, and verify with `ninja --version`.
+4. **Python 3.11 (or newer 3.10+)**
    - Install from [python.org](https://www.python.org/downloads/windows/), making sure to check the option to *Add python.exe to PATH*.
    - After installation, verify the interpreter with `python --version`.
-4. *(Optional but recommended)* **Git for Windows**
+5. *(Optional but recommended)* **Git for Windows**
    - Install from [git-scm.com](https://git-scm.com/download/win) to access Git Bash and command-line tooling.
+6. *(Optional)* **[`just`](https://github.com/casey/just) command runner**
+   - Install via `winget install --id Casey.Just`, download the latest release archive, or run `cargo install just`. The helper recipes invoked later (`just python_wheel`, `just python_smoke`) require it.
+7. *(Optional)* **`vcpkg` with `libjpeg-turbo:x64-windows`**
+   - Only needed when decoding JPEG textures during renderer smoke tests.
 
 ## 2. Clone the Repository
 
-Open a *x64 Native Tools Command Prompt for VS 2022* (search from the Start menu) to ensure MSVC and the Windows SDK are on the PATH.
+Open a *x64 Native Tools Command Prompt for VS 2022* (search from the Start menu) to ensure MSVC and the Windows SDK are on the PATH. Clone the repository with submodules so that the vendored dependencies are available locally.
 
 ```bat
-cd %USERPROFILE%\source\repos
+set ROOT=%USERPROFILE%\source\repos
+mkdir "%ROOT%" 2>nul
+cd "%ROOT%"
 git clone --recurse-submodules https://github.com/kunitoki/yup.git
 cd yup
 ```
@@ -38,7 +46,7 @@ git submodule update --init --recursive
 
 ## 3. Configure the Build with CMake
 
-Create a dedicated build directory to keep generated files separate from the source tree. The generator below targets Visual Studio 17 2022 and configures the entire project, including the renderer, tests, and Python module.
+Create a dedicated build directory to keep generated files separate from the source tree. The generator below targets Visual Studio 17 2022 and configures the entire project, including the renderer, tests, and Python module. Run this from the repository root (next to `CMakeLists.txt`).
 
 ```bat
 cmake -S . -B build\msvc-release ^
@@ -53,10 +61,11 @@ cmake -S . -B build\msvc-release ^
 - `-G` and `-A` ensure we target the 64-bit MSVC toolchain.
 - `-DYUP_BUILD_TESTS=ON` enables GoogleTest targets.
 - `-DYUP_BUILD_EXAMPLES=OFF` speeds up compilation when you only need the renderer pipeline.
+- `-DYUP_ENABLE_AUDIO_MODULES=OFF` disables legacy subsystems that are turned off on this Windows-focused branch.
 
 ## 4. Build All Targets
 
-Compile the solution in **Release** mode, including the renderer library, pybind11 module, and tests.
+Compile the solution in **Release** mode, including the renderer library, pybind11 module, and tests. Building Debug afterwards reuses the same generated solution, so you can re-run the command with `--config Debug` once Release succeeds.
 
 ```bat
 cmake --build build\msvc-release --config Release
@@ -81,9 +90,13 @@ From the same Developer Command Prompt, execute the compiled tests via CTest:
 ctest --test-dir build\msvc-release --config Release
 ```
 
-To exercise the Python tests (requires the `.pyd` extension on the Python path):
+To exercise the Python tests (requires the `.pyd` extension on the Python path), either rely on the helper recipe or invoke the commands manually:
 
 ```bat
+rem Option 1: helper recipe
+just python_smoke
+
+rem Option 2: manual invocation
 set PYTHONPATH=%CD%\build\msvc-release\python\Release
 python -m pytest python\tests -vv
 ```
@@ -110,6 +123,8 @@ The script will:
 1. Invoke CMake in Release mode if the project is not already built.
 2. Copy `yup_rive_renderer.pyd` into the Python packaging directory.
 3. Call `python -m build --wheel` inside `python\`, producing the wheel under `python\dist`.
+
+You can trigger the same workflow via `just python_wheel` (from the repository root) when the `just` runner is installed.
 
 You can now install the wheel with:
 

--- a/docs/Windows Build and Packaging.md
+++ b/docs/Windows Build and Packaging.md
@@ -1,9 +1,23 @@
 # Windows Build and Packaging Workflow
 
-This guide captures the end-to-end workflow for building the Direct3D11 Rive renderer,
+This guide captures the end-to-end workflow for building the Direct3D 11 Rive renderer,
 packaging the Python bindings, and validating the NDI orchestration path on Windows 11.
-The steps assume Visual Studio 2022 (or another C++20-compatible compiler), Python 3.11+,
-and the Windows 10 or 11 SDK are installed.
+Follow it when you want repeatable "clone → build → smoke test" instructions that match
+the latest toolchain and script automation.
+
+## Before you start
+
+Make sure these prerequisites are installed **before** you open the developer prompt:
+
+| Requirement | Notes |
+| --- | --- |
+| Visual Studio 2022 (Desktop development with C++) | Install the workload together with the Windows 10/11 SDK, MSVC v143 build tools, CMake tools for Windows, and the ATL headers. |
+| CMake 3.28+ and Ninja 1.11+ | Bundled versions in Visual Studio are often older. Install current builds from [cmake.org](https://cmake.org/download/) and [ninja-build.org](https://github.com/ninja-build/ninja/releases). |
+| Python 3.11 (or newer 3.10+) | Check **Add python.exe to PATH** during setup. Verify with `python --version`. |
+| Git for Windows | Required when cloning the repository with submodules. |
+| (Optional) [`just`](https://github.com/casey/just) 1.21+ | The docs reference recipes such as `just python_wheel`. Install from the [GitHub releases](https://github.com/casey/just/releases), via `winget install --id Casey.Just`, or `cargo install just`. |
+| (Optional) `cyndilib==0.0.8` | Enables live NDI transmission smoke tests. The helper script can install it for you. |
+| (Optional) `vcpkg` with `libjpeg-turbo:x64-windows` | Required only when decoding JPEG textures in renderer smoke tests. |
 
 > [!IMPORTANT]
 > This branch intentionally supports **desktop Windows builds only**. The CMake tooling now
@@ -15,7 +29,7 @@ and the Windows 10 or 11 SDK are installed.
 ## 0. Automated bootstrap (optional)
 
 When you want a turnkey setup, run the PowerShell helper from a VS 2022 developer
-prompt:
+prompt after cloning the repository (`git clone --recurse-submodules https://github.com/kunitoki/yup.git`):
 
 ```powershell
 Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass
@@ -28,12 +42,22 @@ specified configuration (Release by default), produces the Python wheel,
 reinstalls it into the virtual environment, and runs the renderer/NDI smoke
 tests that cover the binding, orchestrator, and CLI layers. Use
 `-Configuration Debug`, `-SkipWheel`, `-SkipSmokeTests`, or `-InstallCyndilib`
-to adjust the workflow.
+to adjust the workflow. Point `-PythonExecutable` at a specific interpreter if
+`py -3.11` is unavailable.
 
 ## 1. Prepare the environment
 
 1. Launch a **x64 Native Tools Command Prompt for VS 2022** so that MSVC, the Windows SDK,
-   and CMake are all on the `PATH`.
+   and CMake are all on the `PATH`. Confirm the key tools respond as expected:
+
+   ```powershell
+   cl
+   cmake --version
+   ninja --version
+   python --version
+   just --version  # optional
+   ```
+
 2. Install Python dependencies into a clean virtual environment:
 
    ```powershell
@@ -49,7 +73,7 @@ to adjust the workflow.
 
 4. Install the JPEG raster dependency if you plan to decode `.jpeg` assets. The build now
    consumes `libjpeg-turbo`'s CMake config automatically, so installing the vcpkg port is
-   sufficient:
+   sufficient. Run this only when `vcpkg` is configured on your machine:
 
    ```powershell
    vcpkg install libjpeg-turbo:x64-windows
@@ -59,6 +83,7 @@ to adjust the workflow.
 
 1. Configure the project with Visual Studio 2022 generators. Disable the legacy audio
    modules to shorten build times while keeping the renderer, bindings, and tests available.
+   Run the command from the repository root (next to `CMakeLists.txt`):
 
    ```powershell
    cmake -S . -B build -G "Visual Studio 17 2022" -A x64 \
@@ -89,7 +114,8 @@ to adjust the workflow.
 ## 3. Build and install the Python wheel
 
 1. From the repository root, build the wheel, reinstall it into the active virtual
-   environment, and run the Python unit tests:
+   environment, and run the Python unit tests. Install `just` if you want to use the
+   convenience recipe (or invoke the underlying commands manually):
 
    ```powershell
    just python_wheel
@@ -120,7 +146,8 @@ just python_smoke
 
 The command executes the targeted smoke tests with `-q` so that any failures surface
 immediately. The tests ship with fake renderer/sender implementations, so they succeed even
-when GPU or NDI runtimes are absent.
+when GPU or NDI runtimes are absent. To run the tests manually, invoke `python -m pytest`
+with the same paths listed in the recipe.
 
 ## 5. Package distributables
 
@@ -149,3 +176,7 @@ when GPU or NDI runtimes are absent.
   to compile. Replace raw `sleep()`/`Sleep()` usages in platform code (e.g. the DirectSound
   backend) with `Thread::sleep(milliseconds)` so the implementation maps cleanly onto the
   Windows API.
+
+- **`just` is not recognized** – Install the utility via `winget install --id Casey.Just` or
+  download the latest release from GitHub and add it to `PATH`. Alternatively, run the
+  equivalent `python -m build`/`python -m pytest` commands directly.


### PR DESCRIPTION
## Summary
- expand both Windows build guides with up-to-date prerequisites, submodule cloning steps, and `just` usage notes
- align the packaging walkthrough with the automated PowerShell installer and manual smoke-test commands
- point the repository README and AGENTS guide at the refreshed documentation so contributors land on the right instructions

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da751ecce48329a74a1b15315aebf7